### PR TITLE
Fix issue 190

### DIFF
--- a/internal/controllers/datasets.go
+++ b/internal/controllers/datasets.go
@@ -161,6 +161,11 @@ func (c *Datasets) AddImport(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 		messages := make([]string, 0)
+		/*
+			TODO: when datacite does not provide the necessary information for a record
+				  to validate, this list will be too long to show, and there is no
+				  way to attach an error to a specific field as we do not have a full form.
+		*/
 		switch cErr := err.(type) {
 		case jsonapi.Errors:
 			for _, e := range cErr {

--- a/internal/translations/translations.go
+++ b/internal/translations/translations.go
@@ -509,4 +509,8 @@ func init() {
 	message.SetString(language.English, "organization.WE63", "Zoology Museum")
 	message.SetString(language.English, "organization.WE64", "Museum of the History of Sciences")
 	message.SetString(language.English, "organization.WE65", "Honeybee Valley")
+
+	message.SetString(language.English, "dataset.single_import.import_by_id.id_not_found", "Unable to find doi within datasets on datacite.org")
+	message.SetString(language.English, "dataset.single_import.string.minLength", "doi is too short")
+	message.SetString(language.English, "dataset.single_import.import_by_id.import_failed", "Sorry, something went wrong. Could not import the dataset.")
 }


### PR DESCRIPTION
"fixes" #190 

Problem still remains when datacite  does not provide the necessary information
for a record to validate (e.g. no `first_name` for an author). In that case, the flash
box is too small, and there are no specific field (e.g. `first_name`) to which we can
attach that error.