### PR TITLE
show errors on publication import from crossref

### DIFF
--- a/internal/translations/translations.go
+++ b/internal/translations/translations.go
@@ -511,4 +511,8 @@ func init() {
 	message.SetString(language.English, "organization.WE63", "Zoology Museum")
 	message.SetString(language.English, "organization.WE64", "Museum of the History of Sciences")
 	message.SetString(language.English, "organization.WE65", "Honeybee Valley")
+
+	message.SetString(language.English, "publication.single_import.import_by_id.id_not_found", "Unable to find identifier on crossref.org.")
+	message.SetString(language.English, "publication.single_import.string.minLength", "identifier is too short")
+	message.SetString(language.English, "publication.single_import.import_by_id.import_failed", "Sorry, something went wrong. Could not import the dataset.")
 }


### PR DESCRIPTION
one question though: if an identifier is not given, the code from biblio-backend creates an empty publication.
Is that intended?