### PR TITLE
BatchPublishPublications: without page increment this loop takes forever when multipaged

### DIFF
--- a/internal/engine/publication.go
+++ b/internal/engine/publication.go
@@ -130,6 +130,7 @@ func (e *Engine) BatchPublishPublications(userID string, args *SearchArgs) (err 
 		if !hits.NextPage {
 			break
 		}
+		args.Page = args.Page + 1
 	}
 	return
 }


### PR DESCRIPTION
When you've uploaded more than 50 publications from crossref
and wish to "publish all to biblio", the request takes literally forever.
Reason: it expects `next_page` to be false, but that never happens
if you never increment that page argument.