### PR TITLE
add lay summary

### DIFF
--- a/internal/models/publication.go
+++ b/internal/models/publication.go
@@ -255,6 +255,17 @@ func (p *Publication) RemoveContributor(role string, i int) {
 	p.SetContributors(role, append(cc[:i], cc[i+1:]...))
 }
 
+func (p *Publication) UsesLaySummary() bool {
+
+	switch p.Type {
+		case "dissertation":
+			return true
+		default:
+			return false
+	}
+
+}
+
 func (p *Publication) UsesConference() bool {
 	switch p.Type {
 	case "book_chapter", "book_editor", "conference", "issue_editor", "journal_article":

--- a/services/webapp/internal/controllers/publication_lay_summaries.go
+++ b/services/webapp/internal/controllers/publication_lay_summaries.go
@@ -1,0 +1,236 @@
+package controllers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/ugent-library/biblio-backend/internal/models"
+	"github.com/ugent-library/biblio-backend/services/webapp/internal/context"
+	"github.com/ugent-library/biblio-backend/services/webapp/internal/views"
+	"github.com/ugent-library/go-locale/locale"
+	"github.com/ugent-library/go-web/forms"
+	"github.com/ugent-library/go-web/jsonapi"
+	"github.com/unrolled/render"
+)
+
+type PublicationLaySummaries struct {
+	Context
+}
+
+func NewPublicationLaySummaries(c Context) *PublicationLaySummaries {
+	return &PublicationLaySummaries{c}
+}
+
+func (c *PublicationLaySummaries) Add(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+
+	c.Render.HTML(w, http.StatusOK, "publication/lay_summaries/_form", c.ViewData(r, struct {
+		PublicationID string
+		LaySummary      *models.Text
+		Form          *views.FormBuilder
+		Vocabularies  map[string][]string
+	}{
+		PublicationID: id,
+		LaySummary: &models.Text{},
+		Form: views.NewFormBuilder(c.RenderPartial, locale.Get(r.Context()), nil),
+		Vocabularies: c.Engine.Vocabularies(),
+	}),
+		render.HTMLOptions{Layout: "layouts/htmx"},
+	)
+}
+
+// Save a lay summary to Librecat
+func (c *PublicationLaySummaries) Create(w http.ResponseWriter, r *http.Request) {
+	pub := context.GetPublication(r.Context())
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	lay_summary := &models.Text{}
+
+	if err := forms.Decode(lay_summary, r.Form); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	lay_summaries := make([]models.Text, len(pub.LaySummary))
+	copy(lay_summaries, pub.LaySummary)
+
+	lay_summaries = append(lay_summaries, *lay_summary)
+	pub.LaySummary = lay_summaries
+
+	savedPub, err := c.Engine.UpdatePublication(pub)
+
+	if formErrors, ok := err.(jsonapi.Errors); ok {
+		c.Render.HTML(w, http.StatusOK, "publication/lay_summaries/_form", c.ViewData(r, struct {
+			PublicationID string
+			LaySummary      *models.Text
+			Form          *views.FormBuilder
+			Vocabularies  map[string][]string
+		}{
+			PublicationID: savedPub.ID,
+			LaySummary: lay_summary,
+			Form: views.NewFormBuilder(c.RenderPartial, locale.Get(r.Context()), formErrors),
+			Vocabularies: c.Engine.Vocabularies(),
+		}),
+			render.HTMLOptions{Layout: "layouts/htmx"},
+		)
+
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	/*
+		target is modal, so send back empty answer (that closes modal),
+		and update list out of band
+		TODO: if you send back multiple hx-swab-oob (e.g. by sending a Flash message)
+			  then the second hx-swap-oob attribute is ignored (where you're list is),
+			  and so your list is inserted in the .. modal.
+	*/
+	c.Render.HTML(w, http.StatusOK,
+		"publication/lay_summaries/_created",
+		c.ViewData(r, struct {
+			Publication *models.Publication
+		}{
+			Publication: savedPub,
+		}),
+		render.HTMLOptions{Layout: "layouts/htmx"},
+	)
+}
+
+// Show the "Edit lay summary" modal
+func (c *PublicationLaySummaries) Edit(w http.ResponseWriter, r *http.Request) {
+	muxRowDelta := mux.Vars(r)["delta"]
+	rowDelta, _ := strconv.Atoi(muxRowDelta)
+
+	pub := context.GetPublication(r.Context())
+
+	lay_summary := &pub.LaySummary[rowDelta]
+
+	c.Render.HTML(w, http.StatusOK, "publication/lay_summaries/_form_edit", c.ViewData(r, struct {
+		PublicationID string
+		Delta         string
+		LaySummary      *models.Text
+		Form          *views.FormBuilder
+		Vocabularies  map[string][]string
+	}{
+		PublicationID: pub.ID,
+		Delta: muxRowDelta,
+		LaySummary: lay_summary,
+		Form: views.NewFormBuilder(c.RenderPartial, locale.Get(r.Context()), nil),
+		Vocabularies: c.Engine.Vocabularies(),
+	}),
+		render.HTMLOptions{Layout: "layouts/htmx"},
+	)
+}
+
+// // Save the updated lay summary to Librecat
+func (c *PublicationLaySummaries) Update(w http.ResponseWriter, r *http.Request) {
+	muxRowDelta := mux.Vars(r)["delta"]
+	rowDelta, _ := strconv.Atoi(muxRowDelta)
+
+	pub := context.GetPublication(r.Context())
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	lay_summary := &models.Text{}
+
+	if err := forms.Decode(lay_summary, r.Form); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	lay_summaries := make([]models.Text, len(pub.LaySummary))
+	copy(lay_summaries, pub.LaySummary)
+
+	lay_summaries[rowDelta] = *lay_summary
+	pub.LaySummary = lay_summaries
+
+	savedPub, err := c.Engine.UpdatePublication(pub)
+
+	if formErrors, ok := err.(jsonapi.Errors); ok {
+		c.Render.HTML(w, http.StatusOK,
+			"publication/lay_summaries/_form_edit",
+			c.ViewData(r, struct {
+				PublicationID string
+				Delta         string
+				LaySummary      *models.Text
+				Form          *views.FormBuilder
+				Vocabularies  map[string][]string
+			}{
+				PublicationID: savedPub.ID,
+				Delta: strconv.Itoa(rowDelta),
+				LaySummary: lay_summary,
+				Form: views.NewFormBuilder(c.RenderPartial, locale.Get(r.Context()), formErrors),
+				Vocabularies: c.Engine.Vocabularies(),
+			}),
+			render.HTMLOptions{Layout: "layouts/htmx"},
+		)
+
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	c.Render.HTML(w, http.StatusOK, "publication/lay_summaries/_updated", c.ViewData(r, struct {
+		Publication *models.Publication
+	}{
+		Publication: savedPub,
+	},
+	),
+		render.HTMLOptions{Layout: "layouts/htmx"},
+	)
+}
+
+// // Show the "Confirm remove" modal
+func (c *PublicationLaySummaries) ConfirmRemove(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	muxRowDelta := mux.Vars(r)["delta"]
+
+	c.Render.HTML(w, http.StatusOK, "publication/lay_summaries/_modal_confirm_removal", c.ViewData(r, struct {
+		ID  string
+		Key string
+	}{
+		ID: id,
+		Key: muxRowDelta,
+	}),
+		render.HTMLOptions{Layout: "layouts/htmx"},
+	)
+}
+
+// // Remove a lay summary from Librecat
+func (c *PublicationLaySummaries) Remove(w http.ResponseWriter, r *http.Request) {
+	muxRowDelta := mux.Vars(r)["delta"]
+	rowDelta, _ := strconv.Atoi(muxRowDelta)
+
+	pub := context.GetPublication(r.Context())
+
+	lay_summaries := make([]models.Text, len(pub.LaySummary))
+	copy(lay_summaries, pub.LaySummary)
+
+	lay_summaries = append(lay_summaries[:rowDelta], lay_summaries[rowDelta+1:]...)
+	pub.LaySummary = lay_summaries
+
+	// TODO: error handling
+	savedPub, _ := c.Engine.UpdatePublication(pub)
+
+	c.Render.HTML(w, http.StatusOK, "publication/lay_summaries/_deleted", c.ViewData(r, struct {
+		Publication *models.Publication
+	}{
+			Publication: savedPub,
+	},
+	),
+		render.HTMLOptions{Layout: "layouts/htmx"},
+	)
+}

--- a/services/webapp/internal/routes/register.go
+++ b/services/webapp/internal/routes/register.go
@@ -40,6 +40,7 @@ func Register(c controllers.Context) {
 	publicationContributorsController := controllers.NewPublicationContributors(c)
 	publicationDatasetsController := controllers.NewPublicationDatasets(c)
 	publicationAdditionalInfoController := controllers.NewPublicationAdditionalInfo(c)
+	publicationLaySummariesController := controllers.NewPublicationLaySummaries(c)
 
 	datasetsController := controllers.NewDatasets(c)
 	datasetDetailsController := controllers.NewDatasetDetails(c)
@@ -294,6 +295,27 @@ func Register(c controllers.Context) {
 	pubEditRouter.HandleFunc("/htmx/abstracts/remove/{delta}", publicationAbstractsController.Remove).
 		Methods("DELETE").
 		Name("publication_abstracts_remove_abstract")
+
+	// Publication lay summaries HTMX fragments
+	pubEditRouter.HandleFunc("/htmx/lay_summaries/add", publicationLaySummariesController.Add).
+		Methods("GET").
+		Name("publication_lay_summaries_add_lay_summary")
+	pubEditRouter.HandleFunc("/htmx/lay_summaries/create", publicationLaySummariesController.Create).
+		Methods("POST").
+		Name("publication_lay_summaries_create_lay_summary")
+	pubEditRouter.HandleFunc("/htmx/lay_summaries/edit/{delta}", publicationLaySummariesController.Edit).
+		Methods("GET").
+		Name("publication_lay_summaries_edit_lay_summary")
+	pubEditRouter.HandleFunc("/htmx/lay_summaries/update/{delta}", publicationLaySummariesController.Update).
+		Methods("PUT").
+		Name("publication_lay_summaries_update_lay_summary")
+	pubEditRouter.HandleFunc("/htmx/lay_summaries/remove/{delta}", publicationLaySummariesController.ConfirmRemove).
+		Methods("GET").
+		Name("publication_lay_summaries_confirm_remove_from_publication")
+	pubEditRouter.HandleFunc("/htmx/lay_summaries/remove/{delta}", publicationLaySummariesController.Remove).
+		Methods("DELETE").
+		Name("publication_lay_summaries_remove_lay_summary")
+
 	// Publication links HTMX fragments
 	pubEditRouter.HandleFunc("/htmx/links/add", publicationLinksController.Add).
 		Methods("GET").

--- a/services/webapp/internal/translations/translations.go
+++ b/services/webapp/internal/translations/translations.go
@@ -223,6 +223,9 @@ func init() {
 	message.SetString(language.English, "builder.abstract.text", "Abstract")
 	message.SetString(language.English, "builder.abstract.lang", "Language")
 
+	message.SetString(language.English, "builder.lay_summary.text", "Lay Summary")
+	message.SetString(language.English, "builder.lay_summary.lang", "Language")
+
 	message.SetString(language.English, "builder.link.url", "URL")
 	message.SetString(language.English, "builder.link.relation", "Relation")
 	message.SetString(language.English, "builder.link.description", "Description")

--- a/services/webapp/templates/publication/_description_content.gohtml
+++ b/services/webapp/templates/publication/_description_content.gohtml
@@ -8,6 +8,9 @@
         {{end}}
         {{template "publication/abstracts/_show" .}}
         {{template "publication/links/_show" .}}
+        {{if .D.Publication.UsesLaySummary}}
+            {{template "publication/lay_summaries/_show" .}}
+        {{end}}
         {{template "publication/additional_info/_show" .}}
     </div>
 

--- a/services/webapp/templates/publication/lay_summaries/_created.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_created.gohtml
@@ -1,0 +1,3 @@
+<tbody hx-swap-oob="innerHTML:#lay-summaries-table tbody">
+    {{template "publication/lay_summaries/_table_body" .}}
+</tbody>

--- a/services/webapp/templates/publication/lay_summaries/_deleted.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_deleted.gohtml
@@ -1,0 +1,3 @@
+<tbody hx-swap-oob="innerHTML:#lay-summaries-table tbody">
+    {{template "publication/lay_summaries/_table_body" .}}
+</tbody>

--- a/services/webapp/templates/publication/lay_summaries/_form.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_form.gohtml
@@ -1,0 +1,30 @@
+<div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
+<div class="modal show" id="addLaySummary" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Add Lay Summary</h2>
+            </div>
+            <div class="modal-body">
+                {{.D.Form.TextArea (.D.Form.Name "text" (.D.Form.Locale "builder.lay_summary")) (.D.Form.Value .D.LaySummary.Text) (.D.Form.Cols 12) (.D.Form.Rows 6) (.D.Form.Placeholder "Add lay summary text here...")}}
+                {{.D.Form.List (.D.Form.Name "lang" (.D.Form.Locale "builder.lay_summary")) (.D.Form.Value .D.LaySummary.Lang) (.D.Form.Cols 12)
+                    (.D.Form.Choices .D.Vocabularies.language_codes .D.Form.LanguageName)}}
+            </div>
+            <div class="modal-footer">
+                <div class="spinner-border">
+                    <span class="sr-only"></span>
+                </div>
+                <button class="btn btn-link modal-close">Cancel</button>
+                <button type="button" name="create" class="btn btn-primary create-lay-summary"
+                    hx-post="{{pathFor "publication_lay_summaries_create_lay_summary" "id" .D.PublicationID }}"
+                    hx-target="#lay-summaries-modal"
+                    hx-include=".modal-body"
+                    hx-indicator=".modal-dialog .spinner-border"
+                    hx-swap="innerHTML"
+                >
+                    Add lay summary
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/webapp/templates/publication/lay_summaries/_form_edit.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_form_edit.gohtml
@@ -1,0 +1,30 @@
+<div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
+<div class="modal show" id="editLaySummary" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Add Lay Summary</h2>
+            </div>
+            <div class="modal-body">
+                {{.D.Form.TextArea (.D.Form.Name "text" (.D.Form.Locale "builder.lay_summary")) (.D.Form.Value .D.LaySummary.Text) (.D.Form.Cols 12) (.D.Form.Rows 6) (.D.Form.Placeholder "Add lay summary text here...")}}
+                {{.D.Form.List (.D.Form.Name "lang" (.D.Form.Locale "builder.lay_summary")) (.D.Form.Value .D.LaySummary.Lang) (.D.Form.Cols 12)
+                    (.D.Form.Choices .D.Vocabularies.language_codes .D.Form.LanguageName)}}
+            </div>
+            <div class="modal-footer">
+                <div class="spinner-border">
+                    <span class="sr-only"></span>
+                </div>
+                <button class="btn btn-link modal-close">Cancel</button>
+                <button type="button" name="create" class="btn btn-primary"
+                    hx-put="{{pathFor "publication_lay_summaries_update_lay_summary" "id" .D.PublicationID "delta" .D.Delta}}"
+                    hx-target="#lay-summaries-modal"
+                    hx-include=".modal-body"
+                    hx-indicator=".modal-dialog .spinner-border"
+                    hx-swap="innerHTML"
+                >
+                    Update lay summary
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/services/webapp/templates/publication/lay_summaries/_modal_confirm_removal.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_modal_confirm_removal.gohtml
@@ -1,0 +1,23 @@
+<div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
+<div class="modal show" id="removeLaySummaryConfirmation" tabindex="-1" style="display: block;" aria-modal="true" role="dialog">
+<div class="modal-dialog modal-dialog-centered modal-confirm-lay-summary-removal" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 class="modal-title">Are you sure</h2>
+        </div>
+        <div class="modal-body">
+            <p>Are you sure you want to remove this lay summary</p>
+        </div>
+        <div class="modal-footer">
+            <div class="spinner-border">
+                <span class="sr-only"></span>
+            </div>
+            <button class="btn btn-link modal-close">Cancel</button>
+            <button class="btn btn-danger delete-lay-summary"
+                hx-delete="{{pathFor "publication_lay_summaries_remove_lay_summary" "id" .D.ID "delta" .D.Key}}"
+                hx-target="#lay-summaries-modal"
+                hx-indicator=".modal-dialog .spinner-border"
+            >Delete</button>
+        </div>
+    </div>
+</div>

--- a/services/webapp/templates/publication/lay_summaries/_show.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_show.gohtml
@@ -1,0 +1,39 @@
+<div class="card card-collapsible mb-6">
+    <div class="card-header">
+        <div class="collapse-trigger collapsed" data-toggle="collapse" data-target="#collapse-lay-summaries" aria-expanded="false" aria-controls="collapse-lay-summaries"></div>
+        <div class="bc-toolbar">
+            <div class="bc-toolbar-left">
+                <i class="if if-chevron-right mr-4 text-muted"></i>Lay Summary
+            </div>
+            <div class="bc-toolbar-right">
+                {{if .User.CanEditPublication .D.Publication}}
+                <button class="btn btn-outline-primary" type="button"
+                    hx-get="{{pathFor "publication_lay_summaries_add_lay_summary" "id" .D.Publication.ID }}"
+                    hx-swap="innerHTML"
+                    hx-target="#lay-summaries-modal"
+                >
+                    <i class="if if-add"></i>
+                    <div class="btn-text">Add Lay Summary</div>
+                </button>
+                {{end}}
+            </div>
+        </div>
+    </div>
+    <div class="collapse" id="collapse-lay-summaries">
+        <div class="card-body p-0">
+            <table class="table" id="lay-summaries-table">
+                <thead>
+                    <tr>
+                        <th class="pl-6">Text</th>
+                        <th>Language</th>
+                        <th class="pr-6"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{ template "publication/lay_summaries/_table_body" . }}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div id="lay-summaries-modal" class="modals"></div>
+</div>

--- a/services/webapp/templates/publication/lay_summaries/_table_body.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_table_body.gohtml
@@ -1,0 +1,39 @@
+{{range $k, $l := .D.Publication.LaySummary}}
+    {{ $k = $k | toString }}
+    <tr class="row-{{ $k }}">
+        <td class="pl-6">
+            <p>{{ $l.Text }}</p>
+        </td>
+        <td>{{ $.Locale.LanguageName $l.Lang }}</td>
+        <td class="pr-6">
+            {{if $.User.CanEditPublication $.D.Publication}}
+            <div class="c-button-toolbar">
+                <div class="dropdown">
+                    <button class="btn btn-link btn-icon-only btn-link-muted" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="if if-more"></i>
+                    </button>
+                    <div class="dropdown-menu">
+                        <button class="dropdown-item" type="button"
+                            hx-get="{{pathFor "publication_lay_summaries_edit_lay_summary" "id" $.D.Publication.ID "delta" $k}}"
+                            hx-target="#lay-summaries-modal"
+                            hx-swap="innerHTML"
+                        >
+                            <i class="if if-edit"></i>
+                            <span>Edit</span>
+                        </button>
+
+                        <button class="dropdown-item" type="button"
+                            hx-get="{{pathFor "publication_lay_summaries_confirm_remove_from_publication" "id" $.D.Publication.ID "delta" $k}}"
+                            hx-target="#lay-summaries-modal"
+                            hx-swap="innerHTML"
+                        >
+                            <i class="if if-delete"></i>
+                            <span>Delete</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            {{end}}
+        </td>
+    </tr>
+{{end}}

--- a/services/webapp/templates/publication/lay_summaries/_updated.gohtml
+++ b/services/webapp/templates/publication/lay_summaries/_updated.gohtml
@@ -1,0 +1,3 @@
+<tbody hx-swap-oob="innerHTML:#lay-summaries-table tbody">
+    {{template "publication/lay_summaries/_table_body" .}}
+</tbody>


### PR DESCRIPTION
Fixes #299 

Notes:

* I use the modal as the `hx-target` (like in the file attributes dialog). So in order to close it, I have to send empty data, and send extra data with attribute `hx-swap-oob` to update the list in `lay-summaries-table`
* If I use also flash messages, then the flash errors are shown, but .. the list is added to the modal. Apparently only one element with `hx-swap-oob` is used as such, and the rest is treated as content for the hx target. No multiple elements with hx-swap-oob??
* the `hx-swap-oob` element is here a `tbody`. Although it uses the preselector "innerHTML" to fetch only the innerhtml of the source element, that matters apparently. If you use `div`, then all `<tr>` and `<td>` elements are filtered out. Weird, very weird