### PR TITLE
Snapstore search

### DIFF
--- a/etc/es6/dataset.json
+++ b/etc/es6/dataset.json
@@ -14,6 +14,30 @@
                         ]
                     }
                 },
+                "char_filter": {
+                    "equalize_whitespace": {
+                      "type": "pattern_replace",
+                      "pattern": "(\\s{2,})",
+                      "replacement": " "
+                    },
+                    "remove_punctuation": {
+                      "type": "pattern_replace",
+                      "pattern": "\\p{Punct}",
+                      "replacement": " "
+                    }
+                },
+                "filter": {
+                    "token_edge_ngram": {
+                      "type": "edge_ngram",
+                      "min_gram": 2,
+                      "max_gram": 20
+                    },
+                    "phrase_edge_ngram": {
+                      "type": "edge_ngram",
+                      "min_gram": 2,
+                      "max_gram": 50
+                    }
+                },
                 "analyzer": {
                     "ngram": {
                         "tokenizer": "ngram",
@@ -29,6 +53,50 @@
                         "filter": [
                             "lowercase"
                         ]
+                    },
+                    "token_edge_ngram": {
+                      "type": "custom",
+                      "tokenizer": "standard",
+                      "filter": [
+                        "lowercase",
+                        "icu_folding",
+                        "token_edge_ngram"
+                      ]
+                    },
+                    "token_edge_ngram_search": {
+                      "type": "custom",
+                      "tokenizer": "standard",
+                      "filter": [
+                        "lowercase",
+                        "icu_folding"
+                      ]
+                    },
+                    "phrase_edge_ngram": {
+                      "type": "custom",
+                      "char_filter": [
+                        "remove_punctuation",
+                        "equalize_whitespace"
+                      ],
+                      "tokenizer": "keyword",
+                      "filter": [
+                        "lowercase",
+                        "trim",
+                        "icu_folding",
+                        "phrase_edge_ngram"
+                      ]
+                    },
+                    "phrase_edge_ngram_search": {
+                      "type": "custom",
+                      "char_filter": [
+                        "remove_punctuation",
+                        "equalize_whitespace"
+                      ],
+                      "tokenizer": "keyword",
+                      "filter": [
+                        "lowercase",
+                        "trim",
+                        "icu_folding"
+                      ]
                     }
                 }
             }
@@ -78,8 +146,13 @@
                             "fields": {
                                 "ngram": {
                                     "type": "text",
-                                    "analyzer": "ngram",
-                                    "search_analyzer": "lowercase"
+                                    "analyzer": "token_edge_ngram",
+                                    "search_analyzer": "token_edge_ngram_search"
+                                },
+                                "phrase_ngram": {
+                                    "type": "text",
+                                    "analyzer": "phrase_edge_ngram",
+                                    "search_analyzer": "phrase_edge_ngram"
                                 }
                             }
                         },

--- a/etc/es6/publication.json
+++ b/etc/es6/publication.json
@@ -14,6 +14,30 @@
                         ]
                     }
                 },
+                "char_filter": {
+                  "equalize_whitespace": {
+                    "type": "pattern_replace",
+                    "pattern": "(\\s{2,})",
+                    "replacement": " "
+                  },
+                  "remove_punctuation": {
+                    "type": "pattern_replace",
+                    "pattern": "\\p{Punct}",
+                    "replacement": " "
+                  }
+                },
+                "filter": {
+                  "token_edge_ngram": {
+                    "type": "edge_ngram",
+                    "min_gram": 2,
+                    "max_gram": 20
+                  },
+                  "phrase_edge_ngram": {
+                    "type": "edge_ngram",
+                    "min_gram": 2,
+                    "max_gram": 50
+                  }
+                },
                 "analyzer": {
                     "ngram": {
                         "tokenizer": "ngram",
@@ -29,8 +53,52 @@
                         "filter": [
                             "lowercase"
                         ]
+                    },
+                    "token_edge_ngram": {
+                      "type": "custom",
+                      "tokenizer": "standard",
+                      "filter": [
+                        "lowercase",
+                        "icu_folding",
+                        "token_edge_ngram"
+                      ]
+                    },
+                    "token_edge_ngram_search": {
+                      "type": "custom",
+                      "tokenizer": "standard",
+                      "filter": [
+                        "lowercase",
+                        "icu_folding"
+                      ]
+                    },
+                    "phrase_edge_ngram": {
+                      "type": "custom",
+                      "char_filter": [
+                        "remove_punctuation",
+                        "equalize_whitespace"
+                      ],
+                      "tokenizer": "keyword",
+                      "filter": [
+                        "lowercase",
+                        "trim",
+                        "icu_folding",
+                        "phrase_edge_ngram"
+                      ]
+                    },
+                    "phrase_edge_ngram_search": {
+                      "type": "custom",
+                      "char_filter": [
+                        "remove_punctuation",
+                        "equalize_whitespace"
+                      ],
+                      "tokenizer": "keyword",
+                      "filter": [
+                        "lowercase",
+                        "trim",
+                        "icu_folding"
+                      ]
                     }
-                }    
+                }
             }
         }
     },
@@ -78,8 +146,13 @@
                             "fields": {
                                 "ngram": {
                                     "type": "text",
-                                    "analyzer": "ngram",
-                                    "search_analyzer": "lowercase"
+                                    "analyzer": "token_edge_ngram",
+                                    "search_analyzer": "token_edge_ngram_search"
+                                },
+                                "phrase_ngram": {
+                                    "type": "text",
+                                    "analyzer": "phrase_edge_ngram",
+                                    "search_analyzer": "phrase_edge_ngram"
                                 }
                             }
                         },

--- a/internal/backends/es6/dataset.go
+++ b/internal/backends/es6/dataset.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"strings"
@@ -16,8 +17,10 @@ import (
 )
 
 func (c *Client) SearchDatasets(args *models.SearchArgs) (*models.DatasetHits, error) {
-	query, queryFilter, termsFilters := buildDatasetQuery(args)
+	query := buildDatasetQuery(args)
 
+	queryFilters := query["query"].(M)["bool"].(M)["filter"].([]M)
+	queryMust := query["query"].(M)["bool"].(M)["must"].(M)
 	query["size"] = args.Limit()
 	query["from"] = args.Offset()
 
@@ -42,13 +45,18 @@ func (c *Client) SearchDatasets(args *models.SearchArgs) (*models.DatasetHits, e
 
 	// facet filter contains all query and all filters except itself
 	for _, field := range []string{"status"} {
-		filters := []M{queryFilter}
+		filters := []M{queryMust}
 
-		for _, filter := range termsFilters {
+		for _, filter := range queryFilters {
 			terms := filter["terms"]
+			// non facet related filters (keep: always)
+			// TODO: make difference between facet filter
+			// and other filters more explicit
 			if terms == nil {
+				filters = append(filters, filter)
 				continue
 			}
+			// facet related filters (keep: if not matching)
 			if _, found := terms.(M)[field]; found {
 				continue
 			} else {
@@ -62,10 +70,9 @@ func (c *Client) SearchDatasets(args *models.SearchArgs) (*models.DatasetHits, e
 			"aggs": M{
 				"facet": M{
 					"terms": M{
-						"field":         field,
-						"min_doc_count": 1,
-						"order":         M{"_key": "asc"},
-						"size":          200,
+						"field": field,
+						"order": M{"_key": "asc"},
+						"size":  200,
 					},
 				},
 			},
@@ -118,28 +125,82 @@ func (c *Client) SearchDatasets(args *models.SearchArgs) (*models.DatasetHits, e
 	return hits, nil
 }
 
-func buildDatasetQuery(args *models.SearchArgs) (M, M, []M) {
+func buildDatasetQuery(args *models.SearchArgs) M {
 	var query M
-	var queryFilter M
-	var termsFilters []M
+	var queryMust M
+	var queryFilters []M
 
 	if len(args.Query) == 0 {
-		queryFilter = M{
+		queryMust = M{
 			"match_all": M{},
 		}
 	} else {
-		queryFilter = M{
-			"multi_match": M{
-				"query":    args.Query,
-				"fields":   []string{"doi^50", "all"},
-				"operator": "and",
+		// use term based query
+		// regular dis_max or multi_match are query based
+		// and therefore will try to match full query over multiple fields
+		queryMust = M{
+			"simple_query_string": M{
+				"query": args.Query,
+				"fields": []string{
+					"id^100",
+					"doi^50",
+					"title^40",
+					"all",
+					"author.full_name.phrase_ngram^0.05",
+					"author.full_name.ngram^0.01",
+				},
+				"lenient":                             true,
+				"analyze_wildcard":                    false,
+				"default_operator":                    "OR",
+				"minimum_should_match":                "100%",
+				"flags":                               "PHRASE|WHITESPACE",
+				"auto_generate_synonyms_phrase_query": true,
 			},
 		}
 	}
 
-	if args.Filters == nil {
-		query = M{"query": queryFilter}
-	} else {
+	/*
+		query.bool.must: search with score
+		query.bool.should: boost given search results with extra score
+						   make sure minimum_should_match is 0
+	*/
+	queryShould := []M{
+		M{
+			"match_phrase": M{
+				"title": M{
+					"query": args.Query,
+					"boost": 200,
+				},
+			},
+		},
+		M{
+			"match_phrase": M{
+				"author.full_name": M{
+					"query": args.Query,
+					"boost": 200,
+				},
+			},
+		},
+		M{
+			"match_phrase": M{
+				"all": M{
+					"query": args.Query,
+					"boost": 100,
+				},
+			},
+		},
+	}
+	query = M{
+		"query": M{
+			"bool": M{
+				"must":                 queryMust,
+				"minimum_should_match": 0,
+				"should":               queryShould,
+			},
+		},
+	}
+
+	if args.Filters != nil {
 		for field, terms := range args.Filters {
 			orFields := strings.Split(field, "|")
 			if len(orFields) > 1 {
@@ -147,32 +208,21 @@ func buildDatasetQuery(args *models.SearchArgs) (M, M, []M) {
 				for _, orField := range orFields {
 					orFilters = append(orFilters, M{"terms": M{orField: terms}})
 				}
-				termsFilters = append(termsFilters, M{"bool": M{"should": orFilters}})
+				queryFilters = append(queryFilters, M{"bool": M{"should": orFilters, "minimum_should_match": "1"}})
 			} else if strings.HasPrefix(field, "!") {
-				termsFilters = append(termsFilters, M{"bool": M{"must_not": M{"terms": M{field[1:]: terms}}}})
+				queryFilters = append(queryFilters, M{"bool": M{"must_not": M{"terms": M{field[1:]: terms}}}})
 			} else {
-				termsFilters = append(termsFilters, M{"terms": M{field: terms}})
+				queryFilters = append(queryFilters, M{"terms": M{field: terms}})
 			}
 		}
 
-		query = M{
-			"query": M{
-				"bool": M{
-					"must": queryFilter,
-					"filter": M{
-						"bool": M{
-							"must": termsFilters,
-						},
-					},
-				},
-			},
-		}
+		query["query"].(M)["bool"].(M)["filter"] = queryFilters
 	}
 
 	query["size"] = 20
 	query["from"] = (args.Page - 1) * 20
 
-	return query, queryFilter, termsFilters
+	return query
 }
 
 type datasetResEnvelope struct {
@@ -221,8 +271,17 @@ func decodeDatasetRes(res *esapi.Response) (*models.DatasetHits, error) {
 
 		for _, f := range r.Aggregations.Facets[facet].(map[string]interface{})["facet"].(map[string]interface{})["buckets"].([]interface{}) {
 			fv := f.(map[string]interface{})
+			value := ""
+			switch v := fv["key"].(type) {
+			case string:
+				value = v
+			case int:
+				value = fmt.Sprintf("%d", v)
+			case float64:
+				value = fmt.Sprintf("%.2f", v)
+			}
 			hits.Facets[facet] = append(hits.Facets[facet], models.Facet{
-				Value: fv["key"].(string),
+				Value: value,
 				Count: int(fv["doc_count"].(float64)),
 			})
 		}
@@ -293,6 +352,12 @@ func (c *Client) IndexDatasets(inCh <-chan *models.Dataset) {
 		OnError: func(c context.Context, e error) {
 			log.Fatalf("ERROR: %s", e)
 		},
+		/*
+		   TODO: appropriate place for this?
+		   without this a controller may search too soon,
+		   and see no results
+		*/
+		Refresh: "wait_for",
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/internal/backends/es6/dataset.go
+++ b/internal/backends/es6/dataset.go
@@ -44,7 +44,7 @@ func (c *Client) SearchDatasets(args *models.SearchArgs) (*models.DatasetHits, e
 	}
 
 	// facet filter contains all query and all filters except itself
-	for _, field := range []string{"status"} {
+	for _, field := range []string{"status", "faculty"} {
 		filters := []M{queryMust}
 
 		for _, filter := range queryFilters {
@@ -64,18 +64,37 @@ func (c *Client) SearchDatasets(args *models.SearchArgs) (*models.DatasetHits, e
 			}
 		}
 
-		// TODO add faculty facet
-		query["aggs"].(M)["facets"].(M)["aggs"].(M)[field] = M{
-			"filter": M{"bool": M{"must": filters}},
-			"aggs": M{
-				"facet": M{
-					"terms": M{
-						"field": field,
-						"order": M{"_key": "asc"},
-						"size":  200,
+		if field == "faculty" {
+
+			query["aggs"].(M)["facets"].(M)["aggs"].(M)[field] = M{
+				"filter": M{"bool": M{"must": filters}},
+				"aggs": M{
+					"facet": M{
+						"terms": M{
+							"field":   field,
+							"order":   M{"_key": "asc"},
+							"size":    200,
+							"include": "^CA|DS|DI|EB|FW|GE|LA|LW|PS|PP|RE|TW|WE|GUK|UZGent|HOART|HOGENT|HOWEST|IBBT|IMEC|VIB$",
+						},
 					},
 				},
-			},
+			}
+
+		} else {
+
+			query["aggs"].(M)["facets"].(M)["aggs"].(M)[field] = M{
+				"filter": M{"bool": M{"must": filters}},
+				"aggs": M{
+					"facet": M{
+						"terms": M{
+							"field": field,
+							"order": M{"_key": "asc"},
+							"size":  200,
+						},
+					},
+				},
+			}
+
 		}
 	}
 

--- a/internal/backends/es6/publication.go
+++ b/internal/backends/es6/publication.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"strings"
@@ -16,8 +17,10 @@ import (
 )
 
 func (c *Client) SearchPublications(args *models.SearchArgs) (*models.PublicationHits, error) {
-	query, queryFilter, termsFilters := buildPublicationQuery(args)
+	query := buildPublicationQuery(args)
 
+	queryFilters := query["query"].(M)["bool"].(M)["filter"].([]M)
+	queryMust := query["query"].(M)["bool"].(M)["must"].(M)
 	query["size"] = args.Limit()
 	query["from"] = args.Offset()
 
@@ -33,6 +36,8 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 	// 	}
 	// }
 
+	// create global bucket so that not all buckets are influenced by query and filters
+	// name "facets" is not important
 	query["aggs"] = M{
 		"facets": M{
 			"global": M{},
@@ -41,14 +46,19 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 	}
 
 	// facet filter contains all query and all filters except itself
-	for _, field := range []string{"status"} {
-		filters := []M{queryFilter}
+	for _, field := range []string{"status", "type", "completeness_score"} {
+		filters := []M{queryMust}
 
-		for _, filter := range termsFilters {
+		for _, filter := range queryFilters {
 			terms := filter["terms"]
+			// non facet related filters (keep: always)
+			// TODO: make difference between facet filter
+			// and other filters more explicit
 			if terms == nil {
+				filters = append(filters, filter)
 				continue
 			}
+			// facet related filters (keep: if not matching)
 			if _, found := terms.(M)[field]; found {
 				continue
 			} else {
@@ -62,10 +72,9 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 			"aggs": M{
 				"facet": M{
 					"terms": M{
-						"field":         field,
-						"min_doc_count": 1,
-						"order":         M{"_key": "asc"},
-						"size":          200,
+						"field": field,
+						"order": M{"_key": "asc"},
+						"size":  200,
 					},
 				},
 			},
@@ -99,7 +108,6 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 	if err := json.NewEncoder(&buf).Encode(query); err != nil {
 		return nil, err
 	}
-
 	opts = append(opts, c.es.Search.WithBody(&buf))
 
 	res, err := c.es.Search(opts...)
@@ -118,28 +126,83 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 	return hits, nil
 }
 
-func buildPublicationQuery(args *models.SearchArgs) (M, M, []M) {
+func buildPublicationQuery(args *models.SearchArgs) M {
 	var query M
-	var queryFilter M
-	var termsFilters []M
+	var queryMust M
+	var queryFilters []M
 
 	if len(args.Query) == 0 {
-		queryFilter = M{
+		queryMust = M{
 			"match_all": M{},
 		}
 	} else {
-		queryFilter = M{
-			"multi_match": M{
-				"query":    args.Query,
-				"fields":   []string{"doi^50", "all"},
-				"operator": "and",
+		// use term based query
+		// regular dis_max or multi_match are query based
+		// and therefore will try to match full query over multiple fields
+		queryMust = M{
+			"simple_query_string": M{
+				"query": args.Query,
+				"fields": []string{
+					"id^100",
+					"doi^50",
+					"title^40",
+					"all",
+					"author.full_name.phrase_ngram^0.05",
+					"author.full_name.ngram^0.01",
+				},
+				"lenient":                             true,
+				"analyze_wildcard":                    false,
+				"default_operator":                    "OR",
+				"minimum_should_match":                "100%",
+				"flags":                               "PHRASE|WHITESPACE",
+				"auto_generate_synonyms_phrase_query": true,
 			},
 		}
 	}
 
-	if args.Filters == nil {
-		query = M{"query": queryFilter}
-	} else {
+	/*
+		query.bool.must: search with score
+		query.bool.should: boost given search results with extra score
+						   make sure minimum_should_match is 0
+	*/
+	queryShould := []M{
+		M{
+			"match_phrase": M{
+				"title": M{
+					"query": args.Query,
+					"boost": 200,
+				},
+			},
+		},
+		M{
+			"match_phrase": M{
+				"author.full_name": M{
+					"query": args.Query,
+					"boost": 200,
+				},
+			},
+		},
+		M{
+			"match_phrase": M{
+				"all": M{
+					"query": args.Query,
+					"boost": 100,
+				},
+			},
+		},
+	}
+	query = M{
+		"query": M{
+			"bool": M{
+				"must":                 queryMust,
+				"minimum_should_match": "0",
+				"should":               queryShould,
+			},
+		},
+	}
+
+	// query.bool.filter: search without score
+	if args.Filters != nil {
 		for field, terms := range args.Filters {
 			orFields := strings.Split(field, "|")
 			if len(orFields) > 1 {
@@ -147,32 +210,21 @@ func buildPublicationQuery(args *models.SearchArgs) (M, M, []M) {
 				for _, orField := range orFields {
 					orFilters = append(orFilters, M{"terms": M{orField: terms}})
 				}
-				termsFilters = append(termsFilters, M{"bool": M{"should": orFilters}})
+				queryFilters = append(queryFilters, M{"bool": M{"should": orFilters, "minimum_should_match": "1"}})
 			} else if strings.HasPrefix(field, "!") {
-				termsFilters = append(termsFilters, M{"bool": M{"must_not": M{"terms": M{field[1:]: terms}}}})
+				queryFilters = append(queryFilters, M{"bool": M{"must_not": M{"terms": M{field[1:]: terms}}}})
 			} else {
-				termsFilters = append(termsFilters, M{"terms": M{field: terms}})
+				queryFilters = append(queryFilters, M{"terms": M{field: terms}})
 			}
 		}
 
-		query = M{
-			"query": M{
-				"bool": M{
-					"must": queryFilter,
-					"filter": M{
-						"bool": M{
-							"must": termsFilters,
-						},
-					},
-				},
-			},
-		}
+		query["query"].(M)["bool"].(M)["filter"] = queryFilters
 	}
 
 	query["size"] = 20
 	query["from"] = (args.Page - 1) * 20
 
-	return query, queryFilter, termsFilters
+	return query
 }
 
 type publicationResEnvelope struct {
@@ -209,15 +261,25 @@ func decodePublicationRes(res *esapi.Response) (*models.PublicationHits, error) 
 	hits.Total = r.Hits.Total
 
 	hits.Facets = make(map[string][]models.Facet)
-	for _, facet := range []string{"status"} {
+	for _, facet := range []string{"status", "type", "completeness_score"} {
+
 		if _, found := r.Aggregations.Facets[facet]; !found {
 			continue
 		}
 
 		for _, f := range r.Aggregations.Facets[facet].(map[string]interface{})["facet"].(map[string]interface{})["buckets"].([]interface{}) {
 			fv := f.(map[string]interface{})
+			value := ""
+			switch v := fv["key"].(type) {
+			case string:
+				value = v
+			case int:
+				value = fmt.Sprintf("%d", v)
+			case float64:
+				value = fmt.Sprintf("%.2f", v)
+			}
 			hits.Facets[facet] = append(hits.Facets[facet], models.Facet{
-				Value: fv["key"].(string),
+				Value: value,
 				Count: int(fv["doc_count"].(float64)),
 			})
 		}
@@ -288,6 +350,12 @@ func (c *Client) IndexPublications(inCh <-chan *models.Publication) {
 		OnError: func(c context.Context, e error) {
 			log.Fatalf("ERROR: %s", e)
 		},
+		/*
+			TODO: appropriate place for this?
+			without this a controller may search too soon,
+			and see no results
+		*/
+		Refresh: "wait_for",
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/internal/backends/es6/publication.go
+++ b/internal/backends/es6/publication.go
@@ -46,7 +46,7 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 	}
 
 	// facet filter contains all query and all filters except itself
-	for _, field := range []string{"status", "type", "completeness_score"} {
+	for _, field := range []string{"status", "type", "completeness_score", "faculty"} {
 		filters := []M{queryMust}
 
 		for _, filter := range queryFilters {
@@ -66,18 +66,37 @@ func (c *Client) SearchPublications(args *models.SearchArgs) (*models.Publicatio
 			}
 		}
 
-		// TODO add faculty facet
-		query["aggs"].(M)["facets"].(M)["aggs"].(M)[field] = M{
-			"filter": M{"bool": M{"must": filters}},
-			"aggs": M{
-				"facet": M{
-					"terms": M{
-						"field": field,
-						"order": M{"_key": "asc"},
-						"size":  200,
+		if field == "faculty" {
+
+			query["aggs"].(M)["facets"].(M)["aggs"].(M)[field] = M{
+				"filter": M{"bool": M{"must": filters}},
+				"aggs": M{
+					"facet": M{
+						"terms": M{
+							"field":   field,
+							"order":   M{"_key": "asc"},
+							"size":    200,
+							"include": "^CA|DS|DI|EB|FW|GE|LA|LW|PS|PP|RE|TW|WE|GUK|UZGent|HOART|HOGENT|HOWEST|IBBT|IMEC|VIB$",
+						},
 					},
 				},
-			},
+			}
+
+		} else {
+
+			query["aggs"].(M)["facets"].(M)["aggs"].(M)[field] = M{
+				"filter": M{"bool": M{"must": filters}},
+				"aggs": M{
+					"facet": M{
+						"terms": M{
+							"field": field,
+							"order": M{"_key": "asc"},
+							"size":  200,
+						},
+					},
+				},
+			}
+
 		}
 	}
 

--- a/services/webapp/templates/search/_query.gohtml
+++ b/services/webapp/templates/search/_query.gohtml
@@ -1,6 +1,8 @@
 <form class="mb-4" method="GET" action="{{.D.SearchURL}}">
-    {{range .D.SearchArgs.FiltersFor "scope"}}
-    <input type="hidden" name="f[scope]" value="{{.}}">
+    {{range $field, $values := .D.SearchArgs.Filters}}
+        {{range $values}}
+        <input type="hidden" name="f[{{$field}}]" value="{{.}}">
+        {{end}}
     {{end}}
     <div class="form-row">
         <div class="col input-group">


### PR DESCRIPTION
* added ES6 char filters, filters and analyzers
* replaced `multi_match` by `simple_query_string` in publication search and dataset search. This is a term based query, which means that the query string is split into parts first, before feeding them to individual search fields; as compared to the regular `dis_max` and its derivative `multi_match` where the full query string is fed to each individual search field.
* added `bool.should` with `minimum_should_match: 0` that should boost documents (cf. `qf` and `pf` in Solr dismax). In this case phrase queries on the full query string.
* added facet faculty. There is an issue though with the current conversion of `department._id` as it does not include the old  `department.tree`.  This is why the facet is often empty.
* fixed broken form element sort: if you selected a sort, then the current filters were not included.