### PR TITLE
download file as attachment; escape utf 8 file names

### DIFF
--- a/services/webapp/internal/controllers/publication_files.go
+++ b/services/webapp/internal/controllers/publication_files.go
@@ -2,9 +2,11 @@ package controllers
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -43,6 +45,7 @@ func (c *PublicationFiles) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename*=UTF-8''%s", url.PathEscape(file.Filename)))
 	http.ServeFile(w, r, c.fileStore.FilePath(file.SHA256))
 }
 


### PR DESCRIPTION
TODO: disable browser caching? Or does `http.ServeFile` already handles `If-Modified-Since` in a decent way?