### PR TITLE
add facet faculty

### DIFF
--- a/etc/es6/publication.json
+++ b/etc/es6/publication.json
@@ -173,6 +173,7 @@
                 "date_updated": {
                     "type": "date"
                 },
+                "faculty": { "type": "keyword" },
                 "department": {
                     "properties": {
                         "_id": {
@@ -181,7 +182,8 @@
                         "tree": {
                             "properties": {
                                 "_id": {
-                                    "type": "keyword"
+                                    "type": "keyword",
+                                    "copy_to": ["faculty"]
                                 }
                             }
                         }

--- a/internal/backends/es6/publication.go
+++ b/internal/backends/es6/publication.go
@@ -77,10 +77,18 @@ func (publications *Publications) Search(args *models.SearchArgs) (*models.Publi
 					"aggs": M{
 						"facet": M{
 							"terms": M{
-								"field":   field,
-								"order":   M{"_key": "asc"},
-								"size":    200,
-								"include": "^CA|DS|DI|EB|FW|GE|LA|LW|PS|PP|RE|TW|WE|GUK|UZGent|HOART|HOGENT|HOWEST|IBBT|IMEC|VIB$",
+								"field": field,
+								"order": M{"_key": "asc"},
+								"size":  200,
+								//weird, regex not working with carets..
+								//"include": "^CA|DS|DI|EB|FW|GE|LA|LW|PS|PP|RE|TW|WE|GUK|UZGent|HOART|HOGENT|HOWEST|IBBT|IMEC|VIB$",
+								"include": []string{
+									"CA", "DS", "DI", "EB", "FW",
+									"GE", "LA", "LW", "PS", "PP",
+									"RE", "TW", "WE", "GUK", "UZGent",
+									"HOART", "HOGENT", "HOWEST",
+									"IBBT", "IMEC", "VIB",
+								},
 							},
 						},
 					},
@@ -276,7 +284,7 @@ func decodePublicationRes(res *esapi.Response) (*models.PublicationHits, error) 
 	hits.Total = r.Hits.Total
 
 	hits.Facets = make(map[string][]models.Facet)
-	for _, facet := range []string{"status", "type", "completeness_score"} {
+	for _, facet := range []string{"status", "type", "completeness_score", "faculty"} {
 
 		if _, found := r.Aggregations.Facets[facet]; !found {
 			continue


### PR DESCRIPTION
I've created a separate field `faculty` where all values from `department.tree._id` are copied to.
That makes it easier to go from `f[faculty]=LW` to a filter on `department.tree._id` (which
would be another exception to be added to the parseScope code).

Need to reindex.