### PR TITLE
fix change access level file, which left list empty due to contractory hx statements

### DIFF
--- a/services/webapp/templates/publication/files/_list.gohtml
+++ b/services/webapp/templates/publication/files/_list.gohtml
@@ -35,13 +35,21 @@
                                     {{if $canEditPublication}}<i class="if if-caret-down"></i>{{end}}
                                 </span>
                                 {{if $canEditPublication}}
+                                <!--
+                                    hx-target must not be publication-files (but publication-files-modal)
+                                    as the resulting html swaps publication-files
+                                    out of band using hx-swap-oob, leaving publication-files
+                                    eventually empty (contradictory statements).
+                                    Anyway, if there is a validation error (in the future),
+                                    the file modal will show it
+                                -->
                                 <div class="dropdown-menu">
                                     <button
                                         class="dropdown-item{{if eq .AccessLevel "open_access"}} dropdown-item--selected{{end}}"
                                         {{ if not (eq .AccessLevel "open_access") }}
                                         hx-put="{{pathFor "publication_file_update" "id" $.D.Publication.ID "file_id" .ID}}"
                                         hx-vals='{ "access_level": "open_access" }'
-                                        hx-target="#publication-files"
+                                        hx-target="#publication-files-modal"
                                         {{ end }}
                                     >
                                         <i class="if if-download text-success"></i>
@@ -58,7 +66,7 @@
                                         {{ if not (eq .AccessLevel "local") }}
                                         hx-put="{{pathFor "publication_file_update" "id" $.D.Publication.ID "file_id" .ID}}"
                                         hx-vals='{ "access_level": "local" }'
-                                        hx-target="#publication-files"
+                                        hx-target="#publication-files-modal"
                                         {{ end }}
                                     >
                                         <i class="if if-ghent-university text-primary"></i>
@@ -75,7 +83,7 @@
                                         {{ if not (eq .AccessLevel "closed") }}
                                         hx-put="{{pathFor "publication_file_update" "id" $.D.Publication.ID "file_id" .ID}}"
                                         hx-vals='{ "access_level": "closed" }'
-                                        hx-target="#publication-files"
+                                        hx-target="#publication-files-modal"
                                         {{ end }}
                                     >
                                         <i class="if if-eye-off text-muted"></i>


### PR DESCRIPTION
BUG: if you change the file access level from the file list, you'll get a message "ok", but the file list is rendered.. empty!

Reason: the [hx-target](https://github.com/ugent-library/biblio-backend/blob/snapstore/services/webapp/templates/publication/files/_list.gohtml#L44) in the list template is set to the same value as the [hx-swap-oob](https://github.com/ugent-library/biblio-backend/blob/snapstore/services/webapp/templates/publication/files/_update.gohtml#L1) from the response, i.e. they both have `#publication-files`. The swapping into `#publication-files` probably happens first (which is good), after which the rest (i.e. empty) is put into `#publication-files`, which makes that list empty.