### PR TITLE
Handlers files

### DIFF
--- a/internal/app/handlers/publicationediting/files.go
+++ b/internal/app/handlers/publicationediting/files.go
@@ -1,0 +1,601 @@
+package publicationediting
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cshum/imagor/imagorpath"
+	"github.com/spf13/viper"
+	"github.com/ugent-library/biblio-backend/internal/app/localize"
+	"github.com/ugent-library/biblio-backend/internal/bind"
+	"github.com/ugent-library/biblio-backend/internal/models"
+	"github.com/ugent-library/biblio-backend/internal/render"
+	"github.com/ugent-library/biblio-backend/internal/render/flash"
+	"github.com/ugent-library/biblio-backend/internal/render/form"
+	"github.com/ugent-library/biblio-backend/internal/ulid"
+	"github.com/ugent-library/biblio-backend/internal/validation"
+	"github.com/ugent-library/biblio-backend/internal/vocabularies"
+)
+
+type BindFile struct {
+	AccessLevel        string `form:"access_level"`
+	CCLicense          string `form:"cc_license"`
+	Description        string `form:"description"`
+	Embargo            string `form:"embargo"`
+	EmbargoTo          string `form:"embargo_to"`
+	NoLicense          bool   `form:"no_license"`
+	OtherLicense       string `form:"other_license"`
+	PublicationVersion string `form:"publication_version"`
+	Relation           string `form:"relation"`
+	Title              string `form:"title"`
+
+	// for extraction from URL
+	ID string `path:"file_id"`
+	// for error extraction after validation
+	Index int
+}
+
+type YieldEditFile struct {
+	Context
+	File      *models.PublicationFile
+	FileIndex int
+	Form      *form.Form
+}
+type YieldShowFiles struct {
+	Context
+}
+
+type YieldDeleteFile struct {
+	Context
+	File *models.PublicationFile
+}
+
+func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request, ctx Context) {
+	b := BindFile{}
+	if err := bind.Request(r, &b); err != nil {
+		render.BadRequest(w, r, err)
+		return
+	}
+
+	file := ctx.Publication.GetFile(b.ID)
+
+	if file == nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf("attachment; filename*=UTF-8''%s", url.PathEscape(file.Filename)),
+	)
+	http.ServeFile(w, r, h.FileStore.FilePath(file.SHA256))
+}
+
+func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request, ctx Context) {
+
+	// 2GB limit on request body
+	r.Body = http.MaxBytesReader(w, r.Body, 2000000000)
+
+	// buffer limit of 32MB
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	file, handler, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// detect content type
+	buff := make([]byte, 512)
+	_, err = file.Read(buff)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	filetype := http.DetectContentType(buff)
+
+	// rewind
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	pub := ctx.Publication
+
+	// add file to filestore
+	checksum, err := h.FileStore.Add(file)
+
+	if err != nil {
+		// TODO: render flash
+		log.Print(err.Error())
+		ctx.Flash = append(ctx.Flash, flash.Flash{
+			Type:         "error",
+			Body:         "There was a problem adding your file",
+			DismissAfter: 5 * time.Second,
+		})
+		render.Render(w, "publication/refresh_files", YieldShowFiles{
+			Context: ctx,
+		})
+		return
+	}
+
+	// save publication
+	// TODO check if file with same checksum is already present
+	savedPub := pub.Clone()
+	now := time.Now()
+	pubFile := &models.PublicationFile{
+		ID:          ulid.MustGenerate(),
+		AccessLevel: "local",
+		Filename:    handler.Filename,
+		FileSize:    int(handler.Size),
+		ContentType: filetype,
+		SHA256:      checksum,
+		DateCreated: &now,
+		DateUpdated: &now,
+	}
+	savedPub.File = append(savedPub.File, pubFile)
+
+	// add thumbnail(s)
+	h.addThumbnailURLs(savedPub)
+
+	if e := h.Repository.SavePublication(savedPub); e != nil {
+		// TODO: render flash
+		log.Print(e.Error())
+		ctx.Flash = append(ctx.Flash, flash.Flash{
+			Type:         "error",
+			Body:         "There was a problem adding your file",
+			DismissAfter: 5 * time.Second,
+		})
+		render.Render(w, "publication/refresh_files", YieldShowFiles{
+			Context: ctx,
+		})
+		return
+	}
+
+	// update publication in context
+	ctx.Publication = savedPub
+
+	// populate bind with stored publication file
+	bindFile := BindFile{}
+	publicationFileToBind(pubFile, &bindFile)
+	bindFile.Index = len(savedPub.File) - 1
+
+	// render edit file form
+	render.Render(w, "publication/refresh_edit_file", YieldEditFile{
+		Context:   ctx,
+		File:      pubFile,
+		FileIndex: bindFile.Index,
+		Form:      fileForm(ctx, bindFile, nil),
+	})
+
+}
+
+func (h *Handler) EditFile(w http.ResponseWriter, r *http.Request, ctx Context) {
+	b := BindFile{}
+	if err := bind.Request(r, &b); err != nil {
+		render.BadRequest(w, r, err)
+		return
+	}
+
+	var file *models.PublicationFile
+
+	for i, f := range ctx.Publication.File {
+		if f.ID == b.ID {
+			file = f
+			b.Index = i
+			break
+		}
+	}
+
+	if file == nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	publicationFileToBind(file, &b)
+
+	render.Render(w, "publication/edit_file", YieldEditFile{
+		Context:   ctx,
+		File:      file,
+		FileIndex: b.Index,
+		Form:      fileForm(ctx, b, nil),
+	})
+}
+
+func (h *Handler) DeleteFile(w http.ResponseWriter, r *http.Request, ctx Context) {
+	b := BindFile{}
+	if err := bind.Request(r, &b); err != nil {
+		render.BadRequest(w, r, err)
+		return
+	}
+
+	pub := ctx.Publication.Clone()
+	newFile := []*models.PublicationFile{}
+	for _, f := range pub.File {
+		if f.ID != b.ID {
+			newFile = append(newFile, f)
+		}
+	}
+	pub.File = newFile
+
+	// add thumbnail urls
+	h.addThumbnailURLs(pub)
+
+	// save publication
+	if err := h.Repository.SavePublication(pub); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// update publication in context
+	ctx.Publication = pub
+
+	// render
+	render.Render(w, "publication/refresh_files", YieldShowFiles{
+		Context: ctx,
+	})
+
+}
+
+func (h *Handler) ConfirmDeleteFile(w http.ResponseWriter, r *http.Request, ctx Context) {
+
+	b := BindFile{}
+	if err := bind.Request(r, &b); err != nil {
+		render.BadRequest(w, r, err)
+		return
+	}
+
+	file := ctx.Publication.GetFile(b.ID)
+
+	if file == nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	render.Render(w, "publication/confirm_delete_file", YieldDeleteFile{
+		Context: ctx,
+		File:    file,
+	})
+
+}
+
+func (h *Handler) SwitchEditFileByLicense(w http.ResponseWriter, r *http.Request, ctx Context) {
+	b := BindFile{}
+	if err := bind.Request(r, &b); err != nil {
+		render.BadRequest(w, r, err)
+		return
+	}
+
+	triggerEl := r.Header.Get("HX-Trigger-name")
+	var file *models.PublicationFile
+	for i, f := range ctx.Publication.File {
+		if f.ID == b.ID {
+			b.Index = i
+			file = f
+			break
+		}
+	}
+
+	if file == nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	// Conditionally voiding licensing fields based on a triggering element
+	// and dependent element inputs
+
+	// Clear embargo fields when Access Level is set to "open access"
+	if triggerEl == "" {
+		if b.AccessLevel == "open_access" {
+			b.Embargo = ""
+			b.EmbargoTo = ""
+		}
+	}
+
+	// Clear CC License when Embargo To is set to "local" or "empty"
+	if triggerEl == "embargo_to" {
+		if (b.EmbargoTo == "" || b.EmbargoTo == "local") && b.CCLicense != "" {
+			b.CCLicense = ""
+		}
+	}
+
+	// Clear No License (Copyright) when CC License is set to a non-empty value
+	if triggerEl == "cc_license" {
+		if b.CCLicense != "" && b.NoLicense {
+			b.NoLicense = false
+		}
+	}
+
+	// Clear CC License when No License (Copyright) is checked
+	if triggerEl == "no_license" {
+		if b.CCLicense != "" && b.NoLicense {
+			b.CCLicense = ""
+		}
+	}
+
+	render.Render(w, "publication/switch_edit_file_by_license", YieldEditFile{
+		Context:   ctx,
+		File:      file,
+		FileIndex: b.Index,
+		Form:      fileForm(ctx, b, nil),
+	})
+
+}
+
+func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request, ctx Context) {
+	b := BindFile{}
+	if err := bind.Request(r, &b); err != nil {
+		render.BadRequest(w, r, err)
+		return
+	}
+
+	pub := ctx.Publication
+	var file *models.PublicationFile
+	for i, f := range pub.File {
+		if f.ID == b.ID {
+			b.Index = i
+			file = f
+			break
+		}
+	}
+
+	if file == nil {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	// Embargo sanity / paranoia check
+	// Ensure embargo fields are definitely empty when Acces Level is set to "Open Access"
+	if b.AccessLevel == "open_access" || b.EmbargoTo == b.AccessLevel {
+		b.EmbargoTo = ""
+		b.Embargo = ""
+	}
+
+	// copy attributes from bind to file
+	bindToPublicationFile(&b, file)
+
+	// add thumbnails (changes record!)
+	h.addThumbnailURLs(pub)
+
+	// save publication
+	err := h.Repository.SavePublication(pub)
+
+	var validationErrors validation.Errors
+	if errors.As(err, &validationErrors) {
+		render.Render(w, "publication/refresh_edit_file", YieldEditFile{
+			Context:   ctx,
+			File:      file,
+			FileIndex: b.Index,
+			Form:      fileForm(ctx, b, validationErrors),
+		})
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// load publication again
+	pub, err = h.Repository.GetPublication(pub.ID)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// update publication in context
+	ctx.Publication = pub
+
+	// TODO: render success
+	ctx.Flash = append(ctx.Flash, flash.Flash{
+		Type:         "success",
+		Body:         "File was updated successfully",
+		DismissAfter: 5 * time.Second,
+	})
+	render.Render(w, "publication/refresh_files", YieldShowFiles{
+		Context: ctx,
+	})
+}
+
+func fileForm(ctx Context, b BindFile, errors validation.Errors) *form.Form {
+
+	l := ctx.Locale
+	optsAccessLevels := []form.SelectOption{}
+	for _, acl := range vocabularies.Map["publication_file_access_levels"] {
+		optsAccessLevels = append(optsAccessLevels, form.SelectOption{
+			Label: l.TS("publication_file_access_levels", acl),
+			Value: acl,
+		})
+	}
+
+	fields := []form.Field{
+		&form.Text{
+			Name:  "title",
+			Value: b.Title,
+			Label: ctx.T("builder.file.title"),
+			Cols:  12,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale, errors,
+				fmt.Sprintf("/file/%d/title", b.Index)),
+		},
+		&form.Select{
+			Name:        "relation",
+			Value:       b.Relation,
+			Label:       l.T("builder.file.relation"),
+			EmptyOption: true,
+			Options: localize.VocabularySelectOptions(
+				l,
+				"publication_file_relations"),
+			Cols: 12,
+			Error: localize.ValidationErrorAt(
+				l,
+				errors,
+				fmt.Sprintf("/file/%d/relation", b.Index)),
+		},
+		&form.Select{
+			Name:        "publication_version",
+			Value:       b.PublicationVersion,
+			Label:       l.T("builder.file.publication_version"),
+			EmptyOption: true,
+			Options:     localize.VocabularySelectOptions(l, "publication_versions"),
+			Cols:        12,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/publication_version", b.Index)),
+		},
+		&form.RadioButtonGroup{
+			Name:    "access_level",
+			Value:   b.AccessLevel,
+			Label:   l.T("builder.file.access_level"),
+			Options: optsAccessLevels,
+			Cols:    9,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/access_level", b.Index)),
+		},
+	}
+
+	// TODO: make license switch work
+	// based on certain conditions add certain fields
+	// e.g. do not add embargo and embargo_to if access_level == "open_access"
+
+	fields = append(fields,
+		&form.Date{
+			Name:  "embargo",
+			Value: b.Embargo,
+			Label: l.T("builder.file.embargo"),
+			Min:   time.Now().Format("2006-01-02"),
+			Cols:  9,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/embargo", b.Index)),
+		},
+		&form.Select{
+			Name:    "embargo_to",
+			Value:   b.EmbargoTo,
+			Label:   l.T("builder.file.embargo_to"),
+			Options: optsAccessLevels,
+			Cols:    9,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/embargo_to", b.Index)),
+		})
+
+	fields = append(fields,
+		&form.Select{
+			Name:        "cc_license",
+			Value:       b.CCLicense,
+			Label:       l.T("builder.file.cc_license"),
+			EmptyOption: true,
+			Options:     localize.VocabularySelectOptions(l, "cc_licenses"),
+			Cols:        9,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/cc_license", b.Index)),
+		},
+		&form.Checkbox{
+			Template: "publication/checkbox_no_license",
+			Name:     "no_license",
+			Value:    "true",
+			Label:    l.T("builder.file.no_license"),
+			Checked:  b.NoLicense,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/no_license", b.Index)),
+			Vars: struct {
+				ID     string
+				FileID string
+			}{
+				ID:     ctx.Publication.ID,
+				FileID: b.ID,
+			},
+		},
+		&form.Text{
+			Name:  "other_license",
+			Value: b.OtherLicense,
+			Label: l.T("builder.file.other_license"),
+			Cols:  12,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/other_license", b.Index)),
+		},
+		&form.TextArea{
+			Name:  "description",
+			Value: b.Description,
+			Label: l.T("builder.file.description"),
+			Rows:  4,
+			Cols:  12,
+			Error: localize.ValidationErrorAt(
+				ctx.Locale,
+				errors,
+				fmt.Sprintf("/file/%d/description", b.Index)),
+		})
+
+	return form.New().
+		WithTheme("default").
+		WithErrors(localize.ValidationErrors(l, errors)).
+		AddSection(fields...)
+
+}
+
+// TODO clean this up
+func (h *Handler) addThumbnailURLs(p *models.Publication) {
+	var u string
+	for _, f := range p.File {
+		if f.ContentType == "application/pdf" && f.FileSize <= 25000000 {
+			params := imagorpath.Params{
+				Image:  h.FileStore.RelativeFilePath(f.SHA256),
+				FitIn:  true,
+				Width:  156,
+				Height: 156,
+			}
+			p := imagorpath.Generate(params, imagorpath.NewDefaultSigner(viper.GetString("imagor-secret")))
+			u = viper.GetString("imagor-url") + "/" + p
+			f.ThumbnailURL = u
+		}
+	}
+}
+
+func publicationFileToBind(f *models.PublicationFile, b *BindFile) {
+	b.AccessLevel = f.AccessLevel
+	b.CCLicense = f.CCLicense
+	b.Description = f.Description
+	b.Embargo = f.Embargo
+	b.EmbargoTo = f.EmbargoTo
+	b.NoLicense = f.NoLicense
+	b.OtherLicense = f.OtherLicense
+	b.PublicationVersion = f.PublicationVersion
+	b.Relation = f.Relation
+	b.Title = f.Title
+	b.ID = f.ID
+}
+
+func bindToPublicationFile(b *BindFile, f *models.PublicationFile) {
+	f.AccessLevel = b.AccessLevel
+	f.CCLicense = b.CCLicense
+	f.Description = b.Description
+	f.Embargo = b.Embargo
+	f.EmbargoTo = b.EmbargoTo
+	f.NoLicense = b.NoLicense
+	f.OtherLicense = b.OtherLicense
+	f.PublicationVersion = b.PublicationVersion
+	f.Relation = b.Relation
+	f.Title = b.Title
+	f.ID = b.ID
+}

--- a/internal/app/handlers/publicationediting/handler.go
+++ b/internal/app/handlers/publicationediting/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/backends"
+	"github.com/ugent-library/biblio-backend/internal/backends/filestore"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
 	"github.com/ugent-library/biblio-backend/internal/render"
@@ -20,6 +21,7 @@ type Handler struct {
 	OrganizationSearchService backends.OrganizationSearchService
 	OrganizationService       backends.OrganizationService
 	DatasetSearchService      backends.DatasetSearchService
+	FileStore                 *filestore.Store
 }
 
 type Context struct {

--- a/internal/app/handlers/publicationviewing/show.go
+++ b/internal/app/handlers/publicationviewing/show.go
@@ -37,6 +37,12 @@ type YieldShowContributors struct {
 	ActiveSubNav string
 }
 
+type YieldShowFiles struct {
+	Context
+	SubNavs      []string
+	ActiveSubNav string
+}
+
 type YieldShowContributorsRole struct {
 	YieldShowContributors
 	Role string
@@ -80,7 +86,7 @@ func (h *Handler) ShowDescription(w http.ResponseWriter, r *http.Request, ctx Co
 }
 
 func (h *Handler) ShowFiles(w http.ResponseWriter, r *http.Request, ctx Context) {
-	render.Render(w, "publication/show_files", YieldShowContributors{
+	render.Render(w, "publication/show_files", YieldShowFiles{
 		Context:      ctx,
 		SubNavs:      subNavs,
 		ActiveSubNav: "files",

--- a/internal/app/routes/register.go
+++ b/internal/app/routes/register.go
@@ -120,6 +120,7 @@ func Register(services *backends.Services, oldBase controllers.Base, oidcClient 
 		PersonSearchService:       services.PersonSearchService,
 		PersonService:             services.PersonService,
 		DatasetSearchService:      services.DatasetSearchService,
+		FileStore:                 services.FileStore,
 	}
 	orcidHandler := &orcid.Handler{
 		BaseHandler:              baseHandler,
@@ -676,6 +677,36 @@ func Register(services *backends.Services, oldBase controllers.Base, oidcClient 
 		publicationEditingHandler.Wrap(publicationEditingHandler.DeleteContributor)).
 		Methods("DELETE").
 		Name("publication_delete_contributor")
+
+	// edit publication files
+	r.HandleFunc("/publication/{id}/files",
+		publicationEditingHandler.Wrap(publicationEditingHandler.UploadFile)).
+		Methods("POST").
+		Name("publication_upload_file")
+	r.HandleFunc("/publication/{id}/files/{file_id}",
+		publicationEditingHandler.Wrap(publicationEditingHandler.DownloadFile)).
+		Methods("GET").
+		Name("publication_download_file")
+	r.HandleFunc("/publication/{id}/files/{file_id}/edit",
+		publicationEditingHandler.Wrap(publicationEditingHandler.EditFile)).
+		Methods("GET").
+		Name("publication_edit_file")
+	r.HandleFunc("/publication/{id}/files/{file_id}",
+		publicationEditingHandler.Wrap(publicationEditingHandler.UpdateFile)).
+		Methods("PUT").
+		Name("publication_update_file")
+	r.HandleFunc("/publication/{id}/files/{file_id}/edit-by-license",
+		publicationEditingHandler.Wrap(publicationEditingHandler.SwitchEditFileByLicense)).
+		Methods("PUT").
+		Name("publication_edit_file_by_license")
+	r.HandleFunc("/publication/{id}/files/{file_id}/confirm-delete",
+		publicationEditingHandler.Wrap(publicationEditingHandler.ConfirmDeleteFile)).
+		Methods("GET").
+		Name("publication_confirm_delete_file")
+	r.HandleFunc("/publication/{id}/files/{file_id}",
+		publicationEditingHandler.Wrap(publicationEditingHandler.DeleteFile)).
+		Methods("DELETE").
+		Name("publication_delete_file")
 
 	// orcid
 	r.HandleFunc("/publication/orcid",

--- a/internal/render/form/form.go
+++ b/internal/render/form/form.go
@@ -183,8 +183,8 @@ type Date struct {
 	Tooltip  string
 	Required bool
 	Cols     int
-	Min      int
-	Max      int
+	Min      string
+	Max      string
 	Error    string
 	Disabled bool
 }

--- a/internal/render/form/form.go
+++ b/internal/render/form/form.go
@@ -194,16 +194,24 @@ func (f *Date) Render(theme string, w io.Writer) error {
 }
 
 type Checkbox struct {
-	Name    string
-	Value   string
-	Label   string
-	Checked bool
-	Cols    int
-	Error   string
+	Template string
+	Name     string
+	Value    string
+	Label    string
+	Checked  bool
+	Cols     int
+	Error    string
+	Vars     any
 }
 
 func (f *Checkbox) Render(theme string, w io.Writer) error {
-	return render.Templates().ExecuteTemplate(w, path.Join("form", theme, "checkbox"), f)
+	t := "checkbox"
+	if f.Template != "" {
+		t = f.Template
+	}
+	tmpl := path.Join("form", theme, t)
+
+	return render.Templates().ExecuteTemplate(w, tmpl, f)
 }
 
 var HiddenFieldTemplate = template.Must(template.New("").Parse(`<input type="hidden" name="{{.Name}}" value="{{.Value}}">`))

--- a/internal/translations/translations.go
+++ b/internal/translations/translations.go
@@ -677,4 +677,14 @@ func init() {
 	message.SetString(language.English, "validation.publication.supervisor.last_name.required", "Last name is required")
 
 	message.SetString(language.English, "publication.conflict_error", "Publication has been modified by another user. Please reload the page.")
+	message.SetString(language.English, "builder.file.title", "Title")
+	message.SetString(language.English, "builder.file.relation", "Document type")
+	message.SetString(language.English, "builder.file.publication_version", "Publication version")
+	message.SetString(language.English, "builder.file.access_level", "Access level")
+	message.SetString(language.English, "builder.file.embargo", "Embargo period")
+	message.SetString(language.English, "builder.file.embargo_to", "Access level after embargo period")
+	message.SetString(language.English, "builder.file.cc_license", "License")
+	message.SetString(language.English, "builder.file.no_license", "No license (in copyright)")
+	message.SetString(language.English, "builder.file.other_license", "Other license")
+	message.SetString(language.English, "builder.file.description", "Description")
 }

--- a/templates/form/default/publication/checkbox_no_license.gohtml
+++ b/templates/form/default/publication/checkbox_no_license.gohtml
@@ -1,0 +1,14 @@
+<div class="form-group row{{if .Error}} is-invalid{{end}}">
+    <div class="col-{{.Cols}} offset-3">
+      <div class="custom-control custom-checkbox">
+        <input class="custom-control-input{{if .Error}} is-invalid{{end}}" type="checkbox" id="{{.Name}}" name="{{.Name}}"
+          {{if .Checked}}checked{{end}} value="{{.Value}}"
+          hx-put="{{pathFor "publication_edit_file_by_license" "id" .Vars.ID "file_id" .Vars.FileID}}"
+          hx-swap="none"
+          hx-include=".file-attributes"
+        >
+        <label class="custom-control-label" for="{{.Name}}">{{.Label}}</label>
+        {{if .Error}}<div class="invalid-feedback">{{.Error}}</div>{{end}}
+      </div>
+    </div>
+  </div>

--- a/templates/publication/confirm_delete_file.gohtml
+++ b/templates/publication/confirm_delete_file.gohtml
@@ -1,0 +1,20 @@
+<div id="modal-backdrop" class="d-block modal-backdrop fade show"></div>
+<div class="d-block modal show" tabindex="-1" aria-modal="true" role="dialog">
+<div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h2 class="modal-title">Are you sure</h2>
+        </div>
+        <div class="modal-body">
+            <p>Are you sure you want to remove <b>{{.File.Filename}}</b> from the publication?</p>
+        </div>
+        <div class="modal-footer">
+            <button class="btn btn-link modal-close">Cancel</button>
+            <button class="btn btn-danger"
+                hx-delete="{{pathFor "publication_delete_file" "id" .Publication.ID "file_id" .File.ID}}"
+                hx-headers='{"If-Match": "{{.Publication.SnapshotID}}"}'
+                hx-swap="none"
+            >Delete</button>
+        </div>
+    </div>
+</div>

--- a/templates/publication/edit_file.gohtml
+++ b/templates/publication/edit_file.gohtml
@@ -1,0 +1,25 @@
+<div id="modal-backdrop" class="d-block modal-backdrop fade show"></div>
+<div class="d-block modal show" tabindex="-1" aria-modal="true" role="dialog">
+    <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Edit file {{.File.Filename}}</h2>
+            </div>
+            <div class="modal-body file-attributes">
+                {{.Form.Errors.Render}}
+                {{range .Form.Sections}}
+                    {{.Render}}
+                {{end}}
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-link modal-close">Cancel</button>
+                <button class="btn btn-primary modal-close" type="submit"
+                    hx-put="{{pathFor "publication_update_file" "id" .Publication.ID "file_id" .File.ID}}"
+                    hx-headers='{"If-Match": "{{.Publication.SnapshotID}}"}'
+                    hx-include=".file-attributes"
+                    hx-swap="none"
+                >Save</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/publication/files_body.gohtml
+++ b/templates/publication/files_body.gohtml
@@ -1,0 +1,80 @@
+{{ $canEditPublication := .User.CanEditPublication .Publication }}
+<ul class="list-group list-group-flush">
+    {{range .Publication.File}}
+    <li class="list-group-item">
+        <div class="d-flex">
+            <div class="d-flex align-items-center w-100">
+                <div class="position-relative">
+                    {{if .ThumbnailURL}}
+                    <img class="list-group-item-thumbnail" src="{{.ThumbnailURL}}" height="156">
+                    {{else}}
+                    <div class="list-group-item-thumbnail">
+                        <div class="c-thumbnail c-thumbnail--publication c-thumbnail--medium">
+                            <i class="if if-article"></i>
+                        </div>
+                    </div>
+                    {{end}}
+                </div>
+                <div class="list-group-item-content">
+                    <div class="list-group-item-subline">
+                        <div class="list-group-item-subline-left">
+                            <span class="pr-5">
+                                {{with .Relation}}{{$.TS "publication_file_relations" .}}{{end}}
+                                {{with .PublicationVersion}}<span class="ml-3 pl-3 border-left">{{$.TS "publication_versions" .}}</span>{{end}}
+                            </span>
+                            <span class="badge badge-pill badge-outline-success">
+                                {{if eq .AccessLevel "open_access"}}
+                                <i class="if if-download text-success"></i>
+                                {{else if eq .AccessLevel "local"}}
+                                <i class="if if-ghent-university text-primary"></i>
+                                {{else if eq .AccessLevel "closed"}}
+                                <i class="if if-eye-off text-muted"></i>
+                                {{end}}
+                                <span class="badge-text">{{$.TS "publication_file_access_levels" .AccessLevel}}</span>
+                            </span>
+                            {{if .EmbargoTo}}
+                            <span class="text-muted c-body-small pl-5">Changes to {{$.TS "publication_file_access_levels" .EmbargoTo}} on {{.Embargo}}</span>
+                            {{end}}
+                        </div>
+                        <div class="list-group-item-subline-right">
+                            {{if $canEditPublication}}
+                            <div class="c-button-toolbar">
+                                <button class="btn btn-default" type="button"
+                                    hx-get="{{pathFor "publication_edit_file" "id" $.Publication.ID "file_id" .ID}}"
+                                    hx-headers='{"If-Match": "{{$.Publication.SnapshotID}}"}'
+                                    hx-swap="innerHTML"
+                                    hx-target="#modals"
+                                >
+                                    <i class="if if-edit"></i>
+                                </button>
+                                <button class="btn btn-default" type="button"
+                                    hx-get="{{pathFor "publication_confirm_delete_file" "id" $.Publication.ID "file_id" .ID}}"
+                                    hx-headers='{"If-Match": "{{$.Publication.SnapshotID}}"}'
+                                    hx-target="#modals"
+                                    hx-trigger="click"
+                                >
+                                    <i class="if if-delete"></i>
+                                </button>
+                            </div>
+                            {{end}}
+                        </div>
+                    </div>
+                    <div class="list-group-item-text">
+                        <a href="{{pathFor "publication_download_file" "id" $.Publication.ID "file_id" .ID}}">
+                            <h4 class="c-h4">{{.Filename}}</h4>
+                        </a>
+                        {{with .Description}}<p class="text-muted c-body-small">{{.}}</p>{{end}}
+                    </div>
+                    <div class="list-group-item-meta">
+                        <div class="list-group-item-meta-left">
+                            <div class="list-group-item-meta-item">
+                                <span class="text-muted c-body-small">Uploaded {{.DateCreated | date "02-01-2006 at 15:04"}}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </li>
+    {{end}}
+</ul>

--- a/templates/publication/refresh_edit_file.gohtml
+++ b/templates/publication/refresh_edit_file.gohtml
@@ -1,0 +1,3 @@
+<div hx-swap-oob="innerHTML:#modals">
+    {{template "publication/edit_file" .}}
+</div>

--- a/templates/publication/refresh_files.gohtml
+++ b/templates/publication/refresh_files.gohtml
@@ -1,0 +1,4 @@
+<div hx-swap-oob="innerHTML:#modals"></div>
+<div hx-swap-oob="innerHTML:#files-body">
+    {{template "publication/files_body" .}}
+</div>

--- a/templates/publication/show_files.gohtml
+++ b/templates/publication/show_files.gohtml
@@ -2,4 +2,46 @@
     {{template "publication/show_nav" .}}
 </div>
 
-files
+{{ $canEditPublication := .User.CanEditPublication .Publication }}
+<div class="card mb-6">
+    <div class="card-header">
+        <div class="bc-toolbar">
+            <div class="bc-toolbar-left">
+                <div class="bc-toolbar-title">Full text documents</div>
+            </div>
+        </div>
+    </div>
+    <div class="card-body p-0">
+        {{if $canEditPublication}}
+        <form class="p-6"
+            hx-post="{{pathFor "publication_upload_file" "id" .Publication.ID}}"
+            hx-encoding="multipart/form-data"
+            hx-headers='{"If-Match": "{{.Publication.SnapshotID}}"}'
+            hx-swap="none"
+            hx-trigger="change"
+	        hx-indicator=".c-file-upload .spinner-border"
+        >
+            {{.CSRFTag}}
+
+            <div class="c-file-upload">
+                <input type="file" name="file">
+                <div class="c-file-upload__content">
+                    <p>Drag and drop or</p>
+                    <button class="btn btn-outline-primary">Upload file
+                        <div class="spinner-border">
+                            <span class="sr-only"></span>
+                        </div>
+                    </button>
+                </div>
+            </div>
+
+            <small class="form-text text-muted my-3"><a href="https://onderzoektips.ugent.be/en/tips/00002065/#Step3:Addfulltext" target="_blank">Which document format or version should I use?</a></small>
+        </form>
+        <hr>
+        {{end}}
+
+        <div id="files-body">
+            {{template "publication/files_body" .}}
+        </div>
+    </div>
+</div>

--- a/templates/publication/switch_edit_file_by_license.gohtml
+++ b/templates/publication/switch_edit_file_by_license.gohtml
@@ -1,0 +1,3 @@
+<div hx-swap-oob="innerHTML:#modals">
+    {{template "publication/edit_file" .}}
+</div>


### PR DESCRIPTION
TODO:

- edit file modal is not copied from the previous version. That would require the possibility to fetch certain fields from the form element and only render those at the right place in the (custom) template. Now one cannot select those, neither can one distinguish form elements from display elements.
- the "switch by license" is not enabled as it was unclear what the current rules are. The controller is there, and the input `no_license` is configured to fetch that url, but that controller always returns the same form now. Based on the current data, certain fields should not be added to the form, in contrast to before, when fields were simply hidden.
- thumbnail urls are now added before saving (instead of after, which did not save the ThumbnailUrl in the database!)
- flash messages are added in the context object, but within htmx I do not know how to render them, or where.