### PR TITLE
fix issue 381

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/blevesearch/zapx/v14 v14.3.4 // indirect
 	github.com/blevesearch/zapx/v15 v15.3.4 // indirect
 	github.com/coreos/go-oidc/v3 v3.2.0 // indirect
+	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/cshum/imagor v0.9.5/go.mod h1:sxjk3QdjTu4AuYzyLGYNP0Q30rTgcpdNU1N/ScS
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/elastic/go-elasticsearch/v6 v6.8.10 h1:2lN0gJ93gMBXvkhwih5xquldszpm8FlUwqG5sPzr6a8=
 github.com/elastic/go-elasticsearch/v6 v6.8.10/go.mod h1:UwaDJsD3rWLM5rKNFzv9hgox93HoX8utj1kxD9aFUcI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/internal/app/handlers/publicationcreating/import.go
+++ b/internal/app/handlers/publicationcreating/import.go
@@ -320,6 +320,9 @@ func (h *Handler) AddMultipleImport(w http.ResponseWriter, r *http.Request, ctx 
 	}
 	defer file.Close()
 
+	//TODO: why does the code imports zero entries without this?
+	_, _ = file.Seek(0, io.SeekStart)
+
 	batchID, err := h.importPublications(ctx.User.ID, source, file)
 	if err != nil {
 		ctx.Flash = append(ctx.Flash, flash.Flash{
@@ -331,7 +334,7 @@ func (h *Handler) AddMultipleImport(w http.ResponseWriter, r *http.Request, ctx 
 		switch source {
 		case "wos":
 			tmpl = "publication/add_wos"
-		case "bibtext":
+		case "bibtex":
 			tmpl = "publication/add_bibtex"
 		}
 


### PR DESCRIPTION
fixes #381 

Fixed:

- skips utf8 bom while reading (bibtex decoder only)
- lowercase bibtex fields before using them. That file had fields like "Author" instead of "author" for which we check in a map!
- resets file pointer (for all decoders, I needed the multipart file to do this); no idea why this doesn't work without, but it is necessary.
- fixes typo in handling template

TODO:

- `Author-Email` contains invalid values within square brackes, i.e. `@`. Should be reported?