### PR TITLE
add missing fields; delete some fields

### DIFF
--- a/internal/app/displays/book_details.go
+++ b/internal/app/displays/book_details.go
@@ -65,6 +65,18 @@ func bookDetails(l *locale.Locale, p *models.Publication) *display.Display {
 		).
 		AddSection(
 			&display.Text{
+				Label: l.T("builder.series_title"),
+				Value: p.SeriesTitle,
+			},
+			&display.Text{
+				Label: l.T("builder.volume"),
+				Value: p.Volume,
+			},
+			&display.Text{
+				Label: l.T("builder.edition"),
+				Value: p.Edition,
+			},
+			&display.Text{
 				Label: l.T("builder.page_count"),
 				Value: p.PageCount,
 			},

--- a/internal/app/displays/conference_details.go
+++ b/internal/app/displays/conference_details.go
@@ -46,7 +46,7 @@ func conferenceDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Required: true,
 			},
 			&display.Text{
-				Label: l.T("builder.journal_article.publication_abbreviation"),
+				Label: l.T("builder.publication_abbreviation"),
 				Value: p.PublicationAbbreviation,
 			},
 		).
@@ -79,6 +79,10 @@ func conferenceDetails(l *locale.Locale, p *models.Publication) *display.Display
 		).
 		AddSection(
 			&display.Text{
+				Label: l.T("builder.conference.series_title"),
+				Value: p.SeriesTitle,
+			},
+			&display.Text{
 				Label: l.T("builder.volume"),
 				Value: p.Volume,
 			},
@@ -95,8 +99,12 @@ func conferenceDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Value: p.PageCount,
 			},
 			&display.Text{
-				Label: l.T("builder.conference.series_title"),
-				Value: p.SeriesTitle,
+				Label: l.T("builder.article_number"),
+				Value: p.ArticleNumber,
+			},
+			&display.Text{
+				Label: l.T("builder.issue_title"),
+				Value: p.IssueTitle,
 			},
 		).
 		AddSection(

--- a/internal/app/displays/dissertation_details.go
+++ b/internal/app/displays/dissertation_details.go
@@ -69,16 +69,16 @@ func dissertationDetails(l *locale.Locale, p *models.Publication) *display.Displ
 		).
 		AddSection(
 			&display.Text{
+				Label: l.T("builder.series_title"),
+				Value: p.SeriesTitle,
+			},
+			&display.Text{
 				Label: l.T("builder.volume"),
 				Value: p.Volume,
 			},
 			&display.Text{
 				Label: l.T("builder.page_count"),
 				Value: p.PageCount,
-			},
-			&display.Text{
-				Label: l.T("builder.series_title"),
-				Value: p.SeriesTitle,
 			},
 		).
 		AddSection(

--- a/internal/app/displays/editor_details.go
+++ b/internal/app/displays/editor_details.go
@@ -36,10 +36,6 @@ func bookEditorDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Label:  l.T("builder.alternative_title"),
 				Values: p.AlternativeTitle,
 			},
-			&display.Text{
-				Label: l.T("builder.journal_article.publication_abbreviation"),
-				Value: p.PublicationAbbreviation,
-			},
 		).
 		AddSection(
 			&display.List{

--- a/internal/app/handlers/publicationediting/book_details_form.go
+++ b/internal/app/handlers/publicationediting/book_details_form.go
@@ -102,6 +102,27 @@ func bookDetailsForm(l *locale.Locale, publication *models.Publication, errors v
 		).
 		AddSection(
 			&form.Text{
+				Name:  "series_title",
+				Label: l.T("builder.series_title"),
+				Value: publication.SeriesTitle,
+				Cols:  9,
+				Error: localize.ValidationErrorAt(l, errors, "/series_title"),
+			},
+			&form.Text{
+				Name:  "volume",
+				Label: l.T("builder.volume"),
+				Value: publication.Volume,
+				Cols:  3,
+				Error: localize.ValidationErrorAt(l, errors, "/volume"),
+			},
+			&form.Text{
+				Name:  "edition",
+				Label: l.T("builder.edition"),
+				Value: publication.Edition,
+				Cols:  3,
+				Error: localize.ValidationErrorAt(l, errors, "/edition"),
+			},
+			&form.Text{
 				Name:  "page_count",
 				Label: l.T("builder.page_count"),
 				Value: publication.PageCount,

--- a/internal/app/handlers/publicationediting/book_editor_details_form.go
+++ b/internal/app/handlers/publicationediting/book_editor_details_form.go
@@ -48,13 +48,6 @@ func bookEditorDetailsForm(l *locale.Locale, publication *models.Publication, er
 				Cols:   9,
 				Error:  localize.ValidationErrorAt(l, errors, "/alternative_title"),
 			},
-			&form.Text{
-				Name:  "publication_abbreviation",
-				Label: l.T("builder.journal_article.publication_abbreviation"),
-				Value: publication.PublicationAbbreviation,
-				Cols:  3,
-				Error: localize.ValidationErrorAt(l, errors, "/publication_abbreviation"),
-			},
 		).
 		AddSection(
 			&form.SelectRepeat{

--- a/internal/app/handlers/publicationediting/conference_details_form.go
+++ b/internal/app/handlers/publicationediting/conference_details_form.go
@@ -125,6 +125,13 @@ func conferenceDetailsForm(l *locale.Locale, publication *models.Publication, er
 		).
 		AddSection(
 			&form.Text{
+				Name:  "series_title",
+				Label: l.T("builder.conference.series_title"),
+				Value: publication.SeriesTitle,
+				Cols:  9,
+				Error: localize.ValidationErrorAt(l, errors, "/series_title"),
+			},
+			&form.Text{
 				Name:  "volume",
 				Label: l.T("builder.volume"),
 				Value: publication.Volume,
@@ -160,11 +167,18 @@ func conferenceDetailsForm(l *locale.Locale, publication *models.Publication, er
 				Error: localize.ValidationErrorAt(l, errors, "/page_count"),
 			},
 			&form.Text{
-				Name:  "series_title",
-				Label: l.T("builder.conference.series_title"),
-				Value: publication.SeriesTitle,
-				Cols:  9,
-				Error: localize.ValidationErrorAt(l, errors, "/series_title"),
+				Name:  "article_number",
+				Label: l.T("builder.article_number"),
+				Value: publication.ArticleNumber,
+				Cols:  3,
+				Error: localize.ValidationErrorAt(l, errors, "/article_number"),
+			},
+			&form.Text{
+				Name:  "issue_title",
+				Label: l.T("builder.issue_title"),
+				Value: publication.IssueTitle,
+				Cols:  3,
+				Error: localize.ValidationErrorAt(l, errors, "/issue_title"),
 			},
 		).
 		AddSection(

--- a/internal/app/handlers/publicationediting/dissertation_details_form.go
+++ b/internal/app/handlers/publicationediting/dissertation_details_form.go
@@ -111,6 +111,13 @@ func dissertationDetailsForm(l *locale.Locale, publication *models.Publication, 
 		).
 		AddSection(
 			&form.Text{
+				Name:  "series_title",
+				Label: l.T("builder.series_title"),
+				Value: publication.SeriesTitle,
+				Cols:  9,
+				Error: localize.ValidationErrorAt(l, errors, "/series_title"),
+			},
+			&form.Text{
 				Name:  "volume",
 				Label: l.T("builder.volume"),
 				Value: publication.Volume,
@@ -123,13 +130,6 @@ func dissertationDetailsForm(l *locale.Locale, publication *models.Publication, 
 				Value: publication.PageCount,
 				Cols:  3,
 				Error: localize.ValidationErrorAt(l, errors, "/page_count"),
-			},
-			&form.Text{
-				Name:  "series_title",
-				Label: l.T("builder.series_title"),
-				Value: publication.SeriesTitle,
-				Cols:  9,
-				Error: localize.ValidationErrorAt(l, errors, "/series_title"),
 			},
 		).
 		AddSection(


### PR DESCRIPTION
Fixes #479 and more:

* book:
  * add missing fields `series_title`, `volume` and `edition`
* conference:
  * move `series_title` to top of section
  * add missing fields `article_number` and `issue_title`
  * rename label for `publication_abbreviation` (was "short journal title", but should be general "publication short title", like in librecat)
* dissertation
  * move `series_title` to top of section
* book_editor:
  * remove field `publication_abbreviation` which is not in librecat