### PR TITLE
Fix issue 522

### DIFF
--- a/internal/backends/es6/facet_config.go
+++ b/internal/backends/es6/facet_config.go
@@ -11,8 +11,13 @@ var publicationFacetFields []string = []string{
 	"faculty",
 	"extern",
 	"publication_status",
+	"locked",
 }
-var datasetFacetFields []string = []string{"status", "faculty"}
+var datasetFacetFields []string = []string{
+	"status",
+	"faculty",
+	"locked",
+}
 var fixedFacetValues = map[string][]string{
 	//"publication_statuses" includes "deleted"
 	"status":             vocabularies.Map["visible_publication_statuses"],
@@ -20,6 +25,7 @@ var fixedFacetValues = map[string][]string{
 	"faculty":            vocabularies.Map["faculties"],
 	"extern":             {"true", "false"},
 	"publication_status": vocabularies.Map["publication_publishing_statuses"],
+	"locked":             {"true", "false"},
 }
 
 func reorderFacets(t string, facets []models.Facet) []models.Facet {

--- a/internal/translations/translations.go
+++ b/internal/translations/translations.go
@@ -713,4 +713,6 @@ func init() {
 
 	message.SetString(language.English, "extern.true", "UGent")
 	message.SetString(language.English, "extern.false", "non UGent")
+	message.SetString(language.English, "locked.true", "locked")
+	message.SetString(language.English, "locked.false", "unlocked")
 }

--- a/views/dataset/pages/search.gohtml
+++ b/views/dataset/pages/search.gohtml
@@ -62,6 +62,7 @@
         <div class="d-flex flex-wrap mb-6">
             {{partial "search/status_facet" .}}
             {{partial "search/faculty_facet" .}}
+            {{partial "search/locked_facet" .}}
         </div>
 
         <div class="card mb-6">

--- a/views/publication/pages/add_multiple_description.gohtml
+++ b/views/publication/pages/add_multiple_description.gohtml
@@ -31,6 +31,7 @@
             {{partial "search/faculty_facet" .}}
             {{partial "search/extern_facet" .}}
             {{partial "search/publication_status_facet" .}}
+            {{partial "search/locked_facet" .}}
         </div>
 
         <div class="card mb-6">

--- a/views/publication/pages/search.gohtml
+++ b/views/publication/pages/search.gohtml
@@ -83,6 +83,7 @@
             {{partial "search/faculty_facet" .}}
             {{partial "search/extern_facet" .}}
             {{partial "search/publication_status_facet" .}}
+            {{partial "search/locked_facet" .}}
         </div>
 
         <div class="card mb-6">

--- a/views/search/_extern_facet.gohtml
+++ b/views/search/_extern_facet.gohtml
@@ -34,8 +34,8 @@
         <div class="dropdown-body">
             {{range .Hits.Facets.extern}}
             <div class="custom-control custom-checkbox mb-4">
-                <input class="custom-control-input" id="filter-type-{{.Value}}" type="checkbox" name="f[extern]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "extern" .Value}} checked{{end}}>
-                <label class="custom-control-label" for="filter-type-{{.Value}}">{{$.Locale.TS "extern" .Value}} ({{.Count}})</label>
+                <input class="custom-control-input" id="filter-extern-{{.Value}}" type="checkbox" name="f[extern]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "extern" .Value}} checked{{end}}>
+                <label class="custom-control-label" for="filter-extern-{{.Value}}">{{$.Locale.TS "extern" .Value}} ({{.Count}})</label>
             </div>
             {{end}}
         </div>

--- a/views/search/_faculty_facet.gohtml
+++ b/views/search/_faculty_facet.gohtml
@@ -34,8 +34,8 @@
         <div class="dropdown-body">
             {{range .Hits.Facets.faculty}}
             <div class="custom-control custom-checkbox mb-4">
-                <input class="custom-control-input" id="filter-type-{{.Value}}" type="checkbox" name="f[faculty]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "faculty" .Value}} checked{{end}}>
-                <label class="custom-control-label" for="filter-type-{{.Value}}">{{$.Locale.TS "organization" .Value}} ({{.Count}})</label>
+                <input class="custom-control-input" id="filter-faculty-{{.Value}}" type="checkbox" name="f[faculty]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "faculty" .Value}} checked{{end}}>
+                <label class="custom-control-label" for="filter-faculty-{{.Value}}">{{$.Locale.TS "organization" .Value}} ({{.Count}})</label>
             </div>
             {{end}}
         </div>

--- a/views/search/_locked_facet.gohtml
+++ b/views/search/_locked_facet.gohtml
@@ -1,8 +1,8 @@
 <div class="dropdown mt-4">
     <a class="badge badge-pill badge-default mr-3" data-toggle="dropdown" data-persist="true" aria-haspopup="true"
         aria-expanded="false" role="button">
-        <span class="badge-text">Publication status</span>
-        <div class="c-counter c-counter--small">{{len (.SearchArgs.FiltersFor "publication_status")}}</div>
+        <span class="badge-text">Locked</span>
+        <div class="c-counter c-counter--small">{{len (.SearchArgs.FiltersFor "locked")}}</div>
         <i class="if if-caret-down"></i>
     </a>
     <form class="mb-4 dropdown-menu" method="GET" action="{{.CurrentURL|queryClear}}">
@@ -10,7 +10,7 @@
             <div class="bc-toolbar">
                 <div class="bc-toolbar__left">
                     <div class="bc-toolbar__item">
-                        <h6>Publication status</h6>
+                        <h6>Locked</h6>
                     </div>
                 </div>
                 <div class="bc-toolbar__right">
@@ -25,17 +25,17 @@
         <input type="hidden" name="sort" value="{{.}}">
         {{end}}
         {{range $f, $vals := .SearchArgs.Filters}}
-        {{if ne $f "publication_status"}}
+        {{if ne $f "locked"}}
         {{range $vals}}
         <input type="hidden" name="f[{{$f}}]" value="{{.}}">
         {{end}}
         {{end}}
         {{end}}
         <div class="dropdown-body">
-            {{range .Hits.Facets.publication_status}}
+            {{range .Hits.Facets.locked}}
             <div class="custom-control custom-checkbox mb-4">
-                <input class="custom-control-input" id="filter-publication-status-{{.Value}}" type="checkbox" name="f[publication_status]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "publication_status" .Value}} checked{{end}}>
-                <label class="custom-control-label" for="filter-publication-status-{{.Value}}">{{$.Locale.TS "publication_publishing_statuses" .Value}} ({{.Count}})</label>
+                <input class="custom-control-input" id="filter-locked-{{.Value}}" type="checkbox" name="f[locked]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "locked" .Value}} checked{{end}}>
+                <label class="custom-control-label" for="filter-locked-{{.Value}}">{{$.Locale.TS "locked" .Value}} ({{.Count}})</label>
             </div>
             {{end}}
         </div>

--- a/views/search/_status_facet.gohtml
+++ b/views/search/_status_facet.gohtml
@@ -34,8 +34,8 @@
         <div class="dropdown-body">
             {{range .Hits.Facets.status}}
             <div class="custom-control custom-checkbox mb-4">
-                <input class="custom-control-input" id="filter-type-{{.Value}}" type="checkbox" name="f[status]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "status" .Value}} checked{{end}}>
-                <label class="custom-control-label" for="filter-type-{{.Value}}">{{$.Locale.TS "publication_statuses" .Value}} ({{.Count}})</label>
+                <input class="custom-control-input" id="filter-status-{{.Value}}" type="checkbox" name="f[status]" value="{{.Value}}"{{if $.SearchArgs.HasFilter "status" .Value}} checked{{end}}>
+                <label class="custom-control-label" for="filter-status-{{.Value}}">{{$.Locale.TS "publication_statuses" .Value}} ({{.Count}})</label>
             </div>
             {{end}}
         </div>


### PR DESCRIPTION
* fixes #522 
* fixes incorrect label `for` (and associated checkbox inputs). Were al set to `filter-type- {{.Value}}`. Probably due to my copy-and-pasting. Noticed when adding the "locked" filter which started to interfere with "extern" because of same "id" attributes "filter-type-true" en "filter-type-false".