### PR TITLE
clone SearchArgs before applying WithFilter or WithPage

### DIFF
--- a/views/dataset/pages/search.gohtml
+++ b/views/dataset/pages/search.gohtml
@@ -48,7 +48,7 @@
                 {{range .Scopes}}
                 <li class="nav-item">
                     <a class="nav-link{{if $.SearchArgs.HasFilter "scope" .}} active{{end}}"
-                        href="{{pathFor "datasets"|query ($.SearchArgs.WithFilter "scope" .)}}">
+                        href="{{pathFor "datasets"|query ($.SearchArgs.Clone.WithFilter "scope" .)}}">
                         {{$.Locale.TS "dataset.search.scopes" .}}
                     </a>
                 </li>

--- a/views/publication/pages/search.gohtml
+++ b/views/publication/pages/search.gohtml
@@ -66,7 +66,7 @@
                 {{range .Scopes}}
                 <li class="nav-item">
                     <a class="nav-link{{if $.SearchArgs.HasFilter "scope" .}} active{{end}}"
-                        href="{{pathFor "publications"|query ($.SearchArgs.WithFilter "scope" .)}}">
+                        href="{{pathFor "publications"|query ($.SearchArgs.Clone.WithFilter "scope" .)}}">
                         {{$.Locale.TS "publication.search.scopes" .}}
                     </a>
                 </li>

--- a/views/search/_pagination.gohtml
+++ b/views/search/_pagination.gohtml
@@ -1,7 +1,7 @@
 <ul class="pagination">
     {{if .Hits.PreviousPage}}
     <li class="page-item">
-        <a class="page-link" href="{{.CurrentURL|query (.SearchArgs.WithPage (sub .Hits.Page 1|int))}}" aria-label="Previous">
+        <a class="page-link" href="{{.CurrentURL|query (.SearchArgs.Clone.WithPage (sub .Hits.Page 1|int))}}" aria-label="Previous">
             <i class="if if-chevron-left" aria-hidden="true"></i>
         </a>
     </li>
@@ -14,12 +14,12 @@
     {{end}}
     {{range untilStep 1 (min .Hits.LastPage 10|add 1|int) 1}}
         <li class="page-item{{if eq . $.Hits.Page}} active{{end}}">
-            <a class="page-link" href="{{$.CurrentURL|query ($.SearchArgs.WithPage .)}}">{{.}}</a>
+            <a class="page-link" href="{{$.CurrentURL|query ($.SearchArgs.Clone.WithPage .)}}">{{.}}</a>
         </li>
     {{end}}
     {{if .Hits.NextPage}}
     <li class="page-item">
-        <a class="page-link" href="{{.CurrentURL|query (.SearchArgs.WithPage (add .Hits.Page 1|int))}}" aria-label="Next">
+        <a class="page-link" href="{{.CurrentURL|query (.SearchArgs.Clone.WithPage (add .Hits.Page 1|int))}}" aria-label="Next">
             <i class="if if-chevron-right" aria-hidden="true"></i>
         </a>
     </li>


### PR DESCRIPTION
Applying `.WithFilter` or `.WithPage` changes the current `.SearchArgs`.

The result now is that the scope is accidentally set to "created",
after creating the scope tabs ("all", "my publications", "created by me")
where "created" is the last in the list. If you look in the hidden form
in every facet on page "all" of publications, you should see "f[scope]"
incorrectly set to "created".