### PR TITLE
do not add query.should when user query is empty

### DIFF
--- a/internal/backends/es6/dataset.go
+++ b/internal/backends/es6/dataset.go
@@ -192,40 +192,50 @@ func (datasets *Datasets) buildUserQuery(args *models.SearchArgs) M {
 		query.bool.should: boost given search results with extra score
 						   make sure minimum_should_match is 0
 	*/
-	queryShould := []M{
-		{
-			"match_phrase": M{
-				"title": M{
-					"query": args.Query,
-					"boost": 200,
+	if len(args.Query) > 0 {
+		queryShould := []M{
+			{
+				"match_phrase": M{
+					"title": M{
+						"query": args.Query,
+						"boost": 200,
+					},
 				},
 			},
-		},
-		{
-			"match_phrase": M{
-				"author.full_name": M{
-					"query": args.Query,
-					"boost": 200,
+			{
+				"match_phrase": M{
+					"author.full_name": M{
+						"query": args.Query,
+						"boost": 200,
+					},
 				},
 			},
-		},
-		{
-			"match_phrase": M{
-				"all": M{
-					"query": args.Query,
-					"boost": 100,
+			{
+				"match_phrase": M{
+					"all": M{
+						"query": args.Query,
+						"boost": 100,
+					},
 				},
 			},
-		},
-	}
-	query = M{
-		"query": M{
-			"bool": M{
-				"must":                 queryMust,
-				"minimum_should_match": 0,
-				"should":               queryShould,
+		}
+		query = M{
+			"query": M{
+				"bool": M{
+					"must":                 queryMust,
+					"minimum_should_match": 0,
+					"should":               queryShould,
+				},
 			},
-		},
+		}
+	} else {
+		query = M{
+			"query": M{
+				"bool": M{
+					"must": queryMust,
+				},
+			},
+		}
 	}
 
 	if args.Filters != nil {

--- a/internal/backends/es6/publication.go
+++ b/internal/backends/es6/publication.go
@@ -193,40 +193,50 @@ func (publications *Publications) buildUserQuery(args *models.SearchArgs) M {
 		query.bool.should: boost given search results with extra score
 						   make sure minimum_should_match is 0
 	*/
-	queryShould := []M{
-		{
-			"match_phrase": M{
-				"title": M{
-					"query": args.Query,
-					"boost": 200,
+	if len(args.Query) > 0 {
+		queryShould := []M{
+			{
+				"match_phrase": M{
+					"title": M{
+						"query": args.Query,
+						"boost": 200,
+					},
 				},
 			},
-		},
-		{
-			"match_phrase": M{
-				"author.full_name": M{
-					"query": args.Query,
-					"boost": 200,
+			{
+				"match_phrase": M{
+					"author.full_name": M{
+						"query": args.Query,
+						"boost": 200,
+					},
 				},
 			},
-		},
-		{
-			"match_phrase": M{
-				"all": M{
-					"query": args.Query,
-					"boost": 100,
+			{
+				"match_phrase": M{
+					"all": M{
+						"query": args.Query,
+						"boost": 100,
+					},
 				},
 			},
-		},
-	}
-	query = M{
-		"query": M{
-			"bool": M{
-				"must":                 queryMust,
-				"minimum_should_match": "0",
-				"should":               queryShould,
+		}
+		query = M{
+			"query": M{
+				"bool": M{
+					"must":                 queryMust,
+					"minimum_should_match": "0",
+					"should":               queryShould,
+				},
 			},
-		},
+		}
+	} else {
+		query = M{
+			"query": M{
+				"bool": M{
+					"must": queryMust,
+				},
+			},
+		}
 	}
 
 	// query.bool.filter: search without score


### PR DESCRIPTION
Current code adds `query.should` with searches on fields all, title and author.full_name as boosts,
even if the user query is empty.