### PR TITLE
filter on dates since for date_created and date_updated

### DIFF
--- a/internal/app/handlers/datasetsearching/handler.go
+++ b/internal/app/handlers/datasetsearching/handler.go
@@ -33,6 +33,7 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 			render.BadRequest(w, r, err)
 			return
 		}
+		searchArgs.Cleanup()
 
 		fn(w, r, Context{
 			BaseContext: ctx,

--- a/internal/app/handlers/publicationsearching/handler.go
+++ b/internal/app/handlers/publicationsearching/handler.go
@@ -35,6 +35,7 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 			render.BadRequest(w, r, err)
 			return
 		}
+		searchArgs.Cleanup()
 
 		fn(w, r, Context{
 			BaseContext: ctx,

--- a/internal/backends/es6/facet_config.go
+++ b/internal/backends/es6/facet_config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/vocabularies"
 )
 
+//facets that also work as filters
 var fixedFacetValues = map[string][]string{
 	//"publication_statuses" includes "deleted"
 	"status":             vocabularies.Map["visible_publication_statuses"],
@@ -17,6 +18,50 @@ var fixedFacetValues = map[string][]string{
 	"classification":     vocabularies.Map["publication_classifications"],
 	"vabb_type":          vocabularies.Map["publication_vabb_types"],
 	"has_message":        {"true", "false"},
+}
+
+//filter without facet values
+var RegularPublicationFilters = []map[string]string{
+	{
+		"name":  "created_since",
+		"field": "date_created",
+		"type":  "date_since",
+	},
+	{
+		"name":  "updated_since",
+		"field": "date_updated",
+		"type":  "date_since",
+	},
+}
+
+var RegularDatasetFilters = []map[string]string{
+	{
+		"name":  "created_since",
+		"field": "date_created",
+		"type":  "date_since",
+	},
+	{
+		"name":  "updated_since",
+		"field": "date_updated",
+		"type":  "date_since",
+	},
+}
+
+func getRegularPublicationFilter(name string, values ...string) models.Filterable {
+	for _, cf := range RegularPublicationFilters {
+		if cf["name"] == name {
+			return ToTypeFilter(cf["type"], cf["name"], cf["field"], values...)
+		}
+	}
+	return nil
+}
+func getRegularDatasetFilter(name string, values ...string) models.Filterable {
+	for _, cf := range RegularPublicationFilters {
+		if cf["name"] == name {
+			return ToTypeFilter(cf["type"], cf["name"], cf["field"], values...)
+		}
+	}
+	return nil
 }
 
 func reorderFacets(t string, facets []models.Facet) []models.Facet {

--- a/internal/backends/es6/filters.go
+++ b/internal/backends/es6/filters.go
@@ -1,0 +1,93 @@
+package es6
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ugent-library/biblio-backend/internal/models"
+)
+
+//regular field filter: accepts syntax in the filter value
+type FieldFilter struct {
+	models.BaseFilter
+}
+
+func (ff *FieldFilter) ToQuery() map[string]interface{} {
+	return ParseScope(ff.Name, ff.Values...)
+}
+
+func (ff *FieldFilter) GetType() string {
+	return "field"
+}
+
+//date filter
+type DateSinceFilter struct {
+	models.BaseFilter
+}
+
+func (dbf *DateSinceFilter) ToQuery() map[string]interface{} {
+	return map[string]interface{}{
+		"range": map[string]interface{}{
+			dbf.Field: map[string]interface{}{
+				"gte": parseTimeSince(dbf.Values[0]),
+			},
+		},
+	}
+}
+
+func (ff *DateSinceFilter) GetType() string {
+	return "date_since"
+}
+
+var regexYear = regexp.MustCompile(`^\d{4}$`)
+var regexDate = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+func isYear(v string) bool {
+	return regexYear.MatchString(v)
+}
+
+func isDate(v string) bool {
+	return regexDate.MatchString(v)
+}
+
+func parseTimeSince(v string) string {
+
+	v = strings.ToLower(strings.TrimSpace(v))
+
+	if v == "today" {
+		t := time.Now().UTC().Truncate(time.Hour * 24)
+		return FormatTimeUTC(&t)
+	} else if v == "yesterday" {
+		t := time.Now().UTC().Add(time.Hour * (-24)).Truncate(time.Hour * 24)
+		return FormatTimeUTC(&t)
+	} else if isYear(v) {
+		return v + "-01-01T00:00:00Z"
+	} else if isDate(v) {
+		return v + "T00:00:00Z"
+	}
+
+	//invalid time: search for time in the future in order to return 0 results
+	t := time.Now().UTC().AddDate(100, 0, 0).Truncate(time.Hour * 24)
+	return FormatTimeUTC(&t)
+}
+
+func ToTypeFilter(t string, name string, field string, values ...string) models.Filterable {
+
+	if t == "date_since" {
+		f := &DateSinceFilter{}
+		f.Name = name
+		f.Field = field
+		f.Values = values
+		return f
+	} else if t == "field" {
+		f := &FieldFilter{}
+		f.Name = name
+		f.Field = field
+		f.Values = values
+		return f
+	}
+
+	return nil
+
+}

--- a/internal/backends/es6/publication.go
+++ b/internal/backends/es6/publication.go
@@ -68,12 +68,16 @@ func (publications *Publications) Search(args *models.SearchArgs) (*models.Publi
 			filters = append(filters, publications.scopes...)
 			// filters = append(filters, internalFilters...)
 
-			// add external filters only if not matching
+			// TODO: cleanup messy difference between regular filters and
+			// facet based filters (based on the existence of "terms")
 			for _, filter := range queryFilters {
 				terms := filter["terms"]
+				//regular filter
 				if terms == nil {
+					filters = append(filters, filter)
 					continue
 				}
+				//facet based filter: add filter only if not matching
 				if _, found := terms.(M)[field]; found {
 					continue
 				} else {
@@ -241,6 +245,20 @@ func (publications *Publications) buildUserQuery(args *models.SearchArgs) M {
 	// query.bool.filter: search without score
 	if args.Filters != nil {
 		for field, terms := range args.Filters {
+
+			if qf := getRegularPublicationFilter(field, terms...); qf != nil {
+				if len(terms) == 0 {
+					continue
+				}
+				/*
+					TODO: invalid syntax is now solved by creating
+					queries that cannot return any results.
+					Error should be returned
+				*/
+				queryFilters = append(queryFilters, qf.ToQuery())
+				continue
+			}
+
 			queryFilters = append(queryFilters, ParseScope(field, terms...))
 		}
 		query["query"].(M)["bool"].(M)["filter"] = queryFilters

--- a/internal/models/facet.go
+++ b/internal/models/facet.go
@@ -4,3 +4,40 @@ type Facet struct {
 	Value string `json:"value"`
 	Count int    `json:"count"`
 }
+
+/*
+	Name: 		public field name (e.g. url query parameter)
+	Field: 		internal field name (e.g. elasticsearch field)
+	Values:		array of string values
+	Type:		type of filter. To distinguish from other filters
+	ToQuery:	convert and return search engine specific filter
+*/
+type Filterable interface {
+	GetName() string
+	GetField() string
+	GetValues() []string
+	GetType() string
+	ToQuery() map[string]interface{}
+}
+
+type Filter struct {
+	Name   string
+	Field  string
+	Values []string
+}
+
+type BaseFilter struct {
+	Filter
+}
+
+func (bf *BaseFilter) GetName() string {
+	return bf.Name
+}
+
+func (bf *BaseFilter) GetField() string {
+	return bf.Field
+}
+
+func (bf *BaseFilter) GetValues() []string {
+	return bf.Values
+}

--- a/internal/models/search_args.go
+++ b/internal/models/search_args.go
@@ -118,3 +118,28 @@ func (s *SearchArgs) Limit() int {
 func (s *SearchArgs) Offset() int {
 	return (s.Page - 1) * s.PageSize
 }
+
+func (s *SearchArgs) Cleanup() {
+
+	//remove filters with empty values
+	cleanupParams(s.Filters)
+}
+
+func cleanupParams(m map[string][]string) {
+	deleteKeys := make([]string, 0)
+	for key, values := range m {
+		nonEmptyValues := make([]string, 0, len(values))
+		for _, v := range values {
+			if v != "" {
+				nonEmptyValues = append(nonEmptyValues, v)
+			}
+		}
+		m[key] = nonEmptyValues
+		if len(nonEmptyValues) == 0 {
+			deleteKeys = append(deleteKeys, key)
+		}
+	}
+	for _, key := range deleteKeys {
+		delete(m, key)
+	}
+}

--- a/internal/vocabularies/map.go
+++ b/internal/vocabularies/map.go
@@ -21,6 +21,8 @@ var Map = map[string][]string{
 		"classification",
 		"year",
 		"vabb_type",
+		"created_since",
+		"updated_since",
 	},
 	"publication_curation_facets": {
 		"status",
@@ -36,6 +38,8 @@ var Map = map[string][]string{
 		"file.relation",
 		"reviewer_tags",
 		"has_message",
+		"created_since",
+		"updated_since",
 	},
 	"dataset_facets": {
 		"status",
@@ -43,6 +47,8 @@ var Map = map[string][]string{
 		"type",
 		"wos_type",
 		"classification",
+		"created_since",
+		"updated_since",
 	},
 	"dataset_curation_facets": {
 		"status",
@@ -56,6 +62,8 @@ var Map = map[string][]string{
 		"file.relation",
 		"reviewer_tags",
 		"has_message",
+		"created_since",
+		"updated_since",
 	},
 	"licenses": {
 		"CC0-1.0",

--- a/views/search/_created_since_facet.gohtml
+++ b/views/search/_created_since_facet.gohtml
@@ -1,0 +1,37 @@
+<div class="dropdown">
+    <a class="badge badge-pill badge-default mr-3" data-toggle="dropdown" data-persist="true" aria-haspopup="true"
+        aria-expanded="false" role="button">
+        <span class="badge-text">Created since</span>
+        <div class="c-counter c-counter--small">{{len (.SearchArgs.FiltersFor "created_since")}}</div>
+        <i class="if if-caret-down"></i>
+    </a>
+    <form class="dropdown-menu" method="GET" action="{{.CurrentURL|queryClear}}">
+        <div class="bc-navbar bc-navbar--bordered-bottom">
+            <div class="bc-toolbar bc-toolbar--auto">
+                <div class="bc-toolbar-left">
+                    <h4 class="text-nowrap">Updated since</h4>
+                </div>
+            </div>
+        </div>
+        <div class="p-6">
+            <label class="col-form-label">Show records updated since</label>
+            <input class="form-control" type="text" name="f[created_since]" value="{{.SearchArgs.FilterFor "created_since"}}">
+            <small class="form-text text-muted">Type a date (DD/MM/YYYY), year (YYYY) or timing (today, yesterday).</small>
+        </div>
+        <div class="bc-navbar bc-navbar--large">
+            <button class="btn btn-primary btn-block" type="submit">Apply filter</button>
+        </div>
+
+        <input type="hidden" name="q" value="{{.SearchArgs.Query}}">
+        {{range .SearchArgs.Sort}}
+          <input type="hidden" name="sort" value="{{.}}">
+        {{end}}
+        {{range $f, $vals := .SearchArgs.Filters}}
+          {{if ne $f "created_since"}}
+              {{range $vals}}
+                  <input type="hidden" name="f[{{$f}}]" value="{{.}}">
+              {{end}}
+          {{end}}
+        {{end}}
+    </form>
+</div>

--- a/views/search/_updated_since_facet.gohtml
+++ b/views/search/_updated_since_facet.gohtml
@@ -1,0 +1,37 @@
+<div class="dropdown">
+    <a class="badge badge-pill badge-default mr-3" data-toggle="dropdown" data-persist="true" aria-haspopup="true"
+        aria-expanded="false" role="button">
+        <span class="badge-text">Created since</span>
+        <div class="c-counter c-counter--small">{{len (.SearchArgs.FiltersFor "updated_since")}}</div>
+        <i class="if if-caret-down"></i>
+    </a>
+    <form class="dropdown-menu" method="GET" action="{{.CurrentURL|queryClear}}">
+        <div class="bc-navbar bc-navbar--bordered-bottom">
+            <div class="bc-toolbar bc-toolbar--auto">
+                <div class="bc-toolbar-left">
+                    <h4 class="text-nowrap">Updated since</h4>
+                </div>
+            </div>
+        </div>
+        <div class="p-6">
+            <label class="col-form-label">Show records updated since</label>
+            <input class="form-control" type="text" name="f[updated_since]" value="{{.SearchArgs.FilterFor "updated_since"}}">
+            <small class="form-text text-muted">Type a date (DD/MM/YYYY), year (YYYY) or timing (today, yesterday).</small>
+        </div>
+        <div class="bc-navbar bc-navbar--large">
+            <button class="btn btn-primary btn-block" type="submit">Apply filter</button>
+        </div>
+
+        <input type="hidden" name="q" value="{{.SearchArgs.Query}}">
+        {{range .SearchArgs.Sort}}
+          <input type="hidden" name="sort" value="{{.}}">
+        {{end}}
+        {{range $f, $vals := .SearchArgs.Filters}}
+          {{if ne $f "updated_since"}}
+              {{range $vals}}
+                  <input type="hidden" name="f[{{$f}}]" value="{{.}}">
+              {{end}}
+          {{end}}
+        {{end}}
+    </form>
+</div>


### PR DESCRIPTION
Fixes #530 and #531

Notes:

* I added a method `SearchArgs#Cleanup` that removes empty slices, or empty values from the filters. Reason: this type of filter introduces empty values in the url as it is a simple text input, while the other filters work with checkboxes that do not send anything when unchecked. The cleanup is called in both handlers of publications and datasets.
* This is a "new" kind of filter, for which no facets are needed
* Since where are filtering here not just on regular values, but on dates, query syntax errors may occur. As I did not see a way to report this errors, I "fixed" it for now by searching for a date in the far future so it always returns zero results. See `es6.ParseTimeSince`. Maybe not ideal, but expected.