### PR TITLE
Widen modal dialogues for big edit forms

### DIFF
--- a/views/dataset/add_department.gohtml
+++ b/views/dataset/add_department.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Select departments</h2>

--- a/views/dataset/add_project.gohtml
+++ b/views/dataset/add_project.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Select projects</h2>

--- a/views/dataset/add_publication.gohtml
+++ b/views/dataset/add_publication.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Select publications</h2>

--- a/views/dataset/edit_details.gohtml
+++ b/views/dataset/edit_details.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Edit dataset details</h2>

--- a/views/publication/add_dataset.gohtml
+++ b/views/publication/add_dataset.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Select datasets</h2>

--- a/views/publication/add_department.gohtml
+++ b/views/publication/add_department.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Select departments</h2>

--- a/views/publication/add_project.gohtml
+++ b/views/publication/add_project.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Select projects</h2>

--- a/views/publication/edit_additional_info.gohtml
+++ b/views/publication/edit_additional_info.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Edit additional information</h2>

--- a/views/publication/edit_conference.gohtml
+++ b/views/publication/edit_conference.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Edit conference details</h2>

--- a/views/publication/edit_details.gohtml
+++ b/views/publication/edit_details.gohtml
@@ -1,5 +1,5 @@
 {{define "modal_dialog"}}
-<div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable" role="document">
+<div class="modal-dialog modal-dialog-centered modal-fullscreen modal-dialog-scrollable" role="document">
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">Edit publication details</h2>


### PR DESCRIPTION
This will fix https://github.com/ugent-library/biblio-backend/issues/470 partially:
- The modals will now be wide even when your browser window is smaller.
- It also enhances the focus mode.
- Did not happen for small edit screens such as "librarian tags" (now called reviewer tags), because they don't need to be wide.

_Note: It's still not ideal because the form elements behave strange on smaller screens (the labels and inputs are not wide enough and balanced wrong), but that will be taken up in https://github.com/ugent-library/biblio-backend/issues/498_