### PR TITLE
Align form labels to the right on edit mode

### DIFF
--- a/views/display/default/list.gohtml
+++ b/views/display/default/list.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row">
-    <label class="col-sm-3 col-form-label align-self-start">
+    <label class="col-md-3 col-form-label align-self-start">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{if .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.Tooltip}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-sm-9">
+    <div class="col-md-9">
     {{if and .Values .Inline}}
         <ul class="list-inline">
         {{range .Values}}

--- a/views/display/default/text.gohtml
+++ b/views/display/default/text.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row">
-    <label class="col-sm-3 col-form-label align-self-start">
+    <label class="col-md-3 col-form-label align-self-start">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{if .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.Tooltip}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-sm-9">
+    <div class="col-mc-9">
     {{if .Value}}
         {{.Value}}
     {{else}}

--- a/views/fields/default/text.gohtml
+++ b/views/fields/default/text.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row">
-    <label class="col-sm-3 col-form-label align-self-start">
+    <label class="col-md-3 col-form-label align-self-start">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{if .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.Tooltip}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-sm-9">
+    <div class="col-md-9">
     {{if and .Values .List}}
         <ul class="list-unstyled">
         {{range .Values}}

--- a/views/form/default/dataset/access_level.gohtml
+++ b/views/form/default/dataset/access_level.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row{{if .Error}} is-invalid{{end}}">
-    <label class="col-3 col-form-label" for="{{.Name}}">
+    <label class="col-md-3 col-form-label" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}}">
+    <div class="col-md-{{.Cols}}">
         <select class="custom-select form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}"{{if .Disabled}} disabled{{end}}
             hx-put="{{pathFor "dataset_edit_details_access_level" "id" .Vars.ID}}"
             hx-include=".modal-body"

--- a/views/form/default/date.gohtml
+++ b/views/form/default/date.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row{{if .Error}} is-invalid{{end}}">
-    <label class="col-3 col-form-label" for="{{.Name}}">
+    <label class="col-md-3 col-form-label" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}}">
+    <div class="col-md-{{.Cols}}">
         <input class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}" type="date"
             value="{{.Value}}"{{with .Min}} min="{{.}}"{{end}}{{with .Max}} max="{{.}}"{{end}}{{if .Disabled}} disabled{{end}}>
         {{if .Error}}<div class="invalid-feedback">{{.Error}}</div>{{end}}

--- a/views/form/default/radio_button_group.gohtml
+++ b/views/form/default/radio_button_group.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row{{if .Error}} is-invalid{{end}}">
-    <label class="col-3 col-form-label" for="{{.Name}}">
+    <label class="col-md-3 col-form-label" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}}">
+    <div class="col-md-{{.Cols}}">
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
             {{range .Options}}
             <label class="btn btn-secondary active">

--- a/views/form/default/select.gohtml
+++ b/views/form/default/select.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row{{if .Error}} is-invalid{{end}}">
-    <label class="col-3 col-form-label" for="{{.Name}}">
+    <label class="col-md-3 col-form-label" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}}">
+    <div class="col-md-{{.Cols}}">
         <select class="custom-select form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}"{{if .Disabled}} disabled{{end}}>
             {{if .EmptyOption}}<option></option>{{end}}
             {{range .Options}}

--- a/views/form/default/select_repeat.gohtml
+++ b/views/form/default/select_repeat.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row">
-    <label class="col-3 col-form-label d-flex align-items-stretch" for="{{.Name}}">
+    <label class="col-md-3 col-form-label d-flex align-items-stretch" for="{{.Name}}">
          {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
          {{if .Tooltip}}
          <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.Tooltip}}">
@@ -8,7 +8,7 @@
          </a>
          {{end}}
      </label>
-     <div class="col-{{.Cols}} form-values">
+     <div class="col-md-{{.Cols}} form-values">
          {{range $i, $v := .Values}}
          <div class="d-flex mb-3 form-value">
              <select class="custom-select form-control" name="{{$.Name}}[{{$i}}]" data-tmpl-name="{{$.Name}}[{i}]">

--- a/views/form/default/text.gohtml
+++ b/views/form/default/text.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row{{if .Error}} is-invalid{{end}}">
-    <label class="col-3 col-form-label" for="{{.Name}}">
+    <label class="col-md-3 col-form-label" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}}{{if .AutocompleteURL}} autocomplete{{end}}"{{if .AutocompleteURL}} data-target="[name={{.Name}}]"{{end}}>
+    <div class="col-md-{{.Cols}}{{if .AutocompleteURL}} autocomplete{{end}}"{{if .AutocompleteURL}} data-target="[name={{.Name}}]"{{end}}>
         <input class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}" type="text" value="{{.Value}}"
             {{if .AutocompleteURL}}
             autocomplete="off"

--- a/views/form/default/text_area.gohtml
+++ b/views/form/default/text_area.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row{{if .Error}} is-invalid{{end}}">
-    <label class="col-3 col-form-label" for="{{.Name}}">
+    <label class="col-md-3 col-form-label" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}}">
+    <div class="col-md-{{.Cols}}">
         <textarea class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}" rows="{{.Rows}}">{{.Value}}</textarea>
         {{with .Error}}<div class="invalid-feedback">{{.}}</div>{{end}}
         {{with .Help}}<small class="form-text text-muted">{{.}}</small>{{end}}

--- a/views/form/default/text_repeat.gohtml
+++ b/views/form/default/text_repeat.gohtml
@@ -1,5 +1,5 @@
 <div class="form-group row form-text-multiple{{if .Error}} is-invalid{{end}}">
-   <label class="col-3 col-form-label d-flex align-items-stretch" for="{{.Name}}">
+   <label class="col-md-3 col-form-label d-flex align-items-stretch" for="{{.Name}}">
         {{.Label}}{{if .Required}}&nbsp;<abbr class="required" title="Required">*</abbr>{{end}}
         {{with .Tooltip}}
         <a class="text-muted mx-2" href="#" data-container="body" data-toggle="popover" data-trigger="focus" data-placement="right" data-content="{{.}}">
@@ -8,7 +8,7 @@
         </a>
         {{end}}
     </label>
-    <div class="col-{{.Cols}} form-values">
+    <div class="col-md-{{.Cols}} form-values">
         {{range $i, $v := .Values}}
         <div class="form-value">
             <div class="d-flex mb-3">


### PR DESCRIPTION
This will normally fix https://github.com/ugent-library/biblio-backend/issues/498

_Note: I cannot test this locally. To see if it works, open a publication or dataset, and edit the publication details. The labels should be aligned to the right, and if you make the [screen smaller](https://github.com/ugent-library/biblio-backend/issues/364) they will be balanced below each other._