### PR TITLE
Import no update timestamp

### DIFF
--- a/internal/backends/interfaces.go
+++ b/internal/backends/interfaces.go
@@ -69,6 +69,7 @@ type Repository interface {
 	AddDatasetListener(func(*models.Dataset))
 	GetDataset(string) (*models.Dataset, error)
 	GetDatasets([]string) ([]*models.Dataset, error)
+	ImportDataset(*models.Dataset) error
 	SaveDataset(*models.Dataset) error
 	UpdateDataset(string, *models.Dataset) error
 	EachDataset(func(*models.Dataset) bool) error

--- a/internal/backends/interfaces.go
+++ b/internal/backends/interfaces.go
@@ -59,6 +59,7 @@ type Repository interface {
 	GetPublication(string) (*models.Publication, error)
 	GetPublications([]string) ([]*models.Publication, error)
 	SavePublication(*models.Publication) error
+	ImportPublication(*models.Publication) error
 	UpdatePublication(string, *models.Publication) error
 	EachPublication(func(*models.Publication) bool) error
 	EachPublicationSnapshot(func(*models.Publication) bool) error

--- a/internal/backends/repository/repository.go
+++ b/internal/backends/repository/repository.go
@@ -284,6 +284,22 @@ func (s *Repository) GetDatasets(ids []string) ([]*models.Dataset, error) {
 	return datasets, nil
 }
 
+func (s *Repository) ImportDataset(d *models.Dataset) error {
+
+	if d.DateCreated == nil {
+		return fmt.Errorf("unable to import old dataset %s: date_created is not set", d.ID)
+	}
+	if d.DateUpdated == nil {
+		return fmt.Errorf("unable to import old dataset %s: date_updated is not set", d.ID)
+	}
+
+	if err := d.Validate(); err != nil {
+		return err
+	}
+
+	return s.datasetStore.Add(d.ID, d, s.opts)
+}
+
 func (s *Repository) SaveDataset(d *models.Dataset) error {
 	now := time.Now()
 

--- a/internal/commands/dataset.go
+++ b/internal/commands/dataset.go
@@ -17,6 +17,7 @@ func init() {
 	datasetCmd.AddCommand(datasetGetCmd)
 	datasetCmd.AddCommand(datasetAllCmd)
 	datasetCmd.AddCommand(datasetAddCmd)
+	datasetCmd.AddCommand(datasetImportCmd)
 	rootCmd.AddCommand(datasetCmd)
 }
 
@@ -82,6 +83,53 @@ var datasetAddCmd = &cobra.Command{
 				ID:     ulid.MustGenerate(),
 				Status: "private",
 			}
+			if err := dec.Decode(&d); errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				log.Fatalf("Unable to decode dataset at line %d : %v", lineNo, err)
+			}
+			if err := d.Validate(); err != nil {
+				log.Printf("Validation failed for dataset at line %d : %v", lineNo, err)
+				continue
+			}
+			if err := e.Repository.SaveDataset(&d); err != nil {
+				log.Fatalf("Unable to store dataset from line %d : %v", lineNo, err)
+			}
+
+			indexC <- &d
+		}
+
+		// close indexing channel when all recs are stored
+		close(indexC)
+		// wait for indexing to finish
+		indexWG.Wait()
+	},
+}
+
+var datasetImportCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import datasets",
+	Run: func(cmd *cobra.Command, args []string) {
+		e := Services()
+
+		var indexWG sync.WaitGroup
+
+		// indexing channel
+		indexC := make(chan *models.Dataset)
+
+		// start bulk indexer
+		indexWG.Add(1)
+		go func() {
+			defer indexWG.Done()
+			e.DatasetSearchService.IndexMultiple(indexC)
+		}()
+
+		dec := json.NewDecoder(os.Stdin)
+
+		lineNo := 0
+		for {
+			lineNo += 1
+			d := models.Dataset{}
 			if err := dec.Decode(&d); errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {

--- a/internal/commands/dataset.go
+++ b/internal/commands/dataset.go
@@ -91,7 +91,7 @@ var datasetAddCmd = &cobra.Command{
 				log.Printf("Validation failed for dataset at line %d : %v", lineNo, err)
 				continue
 			}
-			if err := e.Repository.SaveDataset(&d); err != nil {
+			if err := e.Repository.ImportDataset(&d); err != nil {
 				log.Fatalf("Unable to store dataset from line %d : %v", lineNo, err)
 			}
 

--- a/internal/commands/publication.go
+++ b/internal/commands/publication.go
@@ -19,6 +19,7 @@ func init() {
 	publicationCmd.AddCommand(publicationGetCmd)
 	publicationCmd.AddCommand(publicationAllCmd)
 	publicationCmd.AddCommand(publicationAddCmd)
+	publicationCmd.AddCommand(publicationImportCmd)
 	rootCmd.AddCommand(publicationCmd)
 }
 
@@ -109,6 +110,58 @@ var publicationAddCmd = &cobra.Command{
 				Status:         "private",
 				Classification: "U",
 			}
+			if err := dec.Decode(&p); errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
+				log.Fatalf("Unable to decode publication at line %d : %v", lineNo, err)
+			}
+			if err := p.Validate(); err != nil {
+				log.Printf("Validation failed for publication [id: %s] at line %d : %v", p.ID, lineNo, err)
+				continue
+			}
+			if err := e.Repository.SavePublication(&p); err != nil {
+				log.Fatalf("Unable to store publication from line %d : %v", lineNo, err)
+			}
+
+			indexC <- &p
+		}
+
+		// close indexing channel when all recs are stored
+		close(indexC)
+		// wait for indexing to finish
+		indexWG.Wait()
+	},
+}
+
+var publicationImportCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import publications",
+	Run: func(cmd *cobra.Command, args []string) {
+		e := Services()
+
+		var indexWG sync.WaitGroup
+
+		// indexing channel
+		indexC := make(chan *models.Publication)
+
+		// start bulk indexer
+		indexWG.Add(1)
+		go func() {
+			defer indexWG.Done()
+			e.PublicationSearchService.IndexMultiple(indexC)
+		}()
+
+		fmt, _ := cmd.Flags().GetString("format")
+		decFactory, ok := e.PublicationDecoders[fmt]
+		if !ok {
+			log.Fatalf("Unknown format %s", fmt)
+		}
+		dec := decFactory(os.Stdin)
+
+		lineNo := 0
+		for {
+			lineNo += 1
+			p := models.Publication{}
 			if err := dec.Decode(&p); errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {

--- a/internal/commands/publication.go
+++ b/internal/commands/publication.go
@@ -118,7 +118,7 @@ var publicationAddCmd = &cobra.Command{
 				log.Printf("Validation failed for publication [id: %s] at line %d : %v", p.ID, lineNo, err)
 				continue
 			}
-			if err := e.Repository.SavePublication(&p); err != nil {
+			if err := e.Repository.ImportPublication(&p); err != nil {
 				log.Fatalf("Unable to store publication from line %d : %v", lineNo, err)
 			}
 


### PR DESCRIPTION
Fixes #703 

by introducing separate methods `ImportPublication` and `ImportDataset` that requires preexisting timestamps.