### PR TITLE
implement mutate.SetPublisher and mutate.RemovePublisher

### DIFF
--- a/cli/backends.go
+++ b/cli/backends.go
@@ -343,6 +343,8 @@ func newRepo(conn *pgxpool.Pool, personService backends.PersonService, organizat
 			"set_locked":               mutate.SetLocked,
 			"set_wos_id":               mutate.SetWOSID,
 			"set_wos_type":             mutate.SetWOSType,
+			"set_publisher":            mutate.SetPublisher,
+			"remove_publisher":         mutate.RemovePublisher,
 		},
 
 		CandidateRecordLoaders: []repositories.CandidateRecordVisitor{

--- a/mutate/publication.go
+++ b/mutate/publication.go
@@ -300,3 +300,28 @@ func SetWOSType(p *models.Publication, args []string) error {
 	p.WOSType = strings.TrimSpace(args[0])
 	return nil
 }
+
+// SetPublisher sets attribute Publisher of models.Publication to provided value
+// length of args must be 1
+func SetPublisher(p *models.Publication, args []string) error {
+	// TODO: dead code as UsesPublisher always returns true?
+	if !p.UsesPublisher() {
+		return &ArgumentError{}
+	}
+	if len(args) != 1 {
+		return &ArgumentError{"publisher is missing"}
+	}
+	p.Publisher = args[0]
+	return nil
+}
+
+// RemovePublisher sets attribute Publisher of models.Publication to empty string
+// args is ignored
+func RemovePublisher(p *models.Publication, args []string) error {
+	// TODO: dead code as UsesPublisher always returns true?
+	if !p.UsesPublisher() {
+		return &ArgumentError{}
+	}
+	p.Publisher = ""
+	return nil
+}

--- a/mutate/publication_test.go
+++ b/mutate/publication_test.go
@@ -1,0 +1,28 @@
+package mutate
+
+import (
+	"testing"
+
+	"github.com/ugent-library/biblio-backoffice/models"
+)
+
+func TestSetPublisher(t *testing.T) {
+	p := &models.Publication{}
+
+	publisher := "my-publisher"
+	SetPublisher(p, []string{publisher})
+
+	if p.Publisher != publisher {
+		t.Errorf("expected publication.Publisher to be '%s', got '%s'", publisher, p.Publisher)
+	}
+}
+
+func TestRemovePublisher(t *testing.T) {
+	p := &models.Publication{Publisher: "my-publisher"}
+
+	RemovePublisher(p, nil)
+
+	if p.Publisher != "" {
+		t.Errorf("expected publication.Publisher to be '', got '%s'", p.Publisher)
+	}
+}


### PR DESCRIPTION
Fixes #1775 

* adds mutation `set_publisher`
* adds mutation `remove_publisher`
* adds tests for both functions. I used the golang's builtin testing.T suit. I see that in `client/` another one is used. Harmless?